### PR TITLE
SceneManagerのDataのデフォルトの型をvoidから適当なUnitTypeに変更したい

### DIFF
--- a/Siv3D/Include/HamFramework/SceneManager.hpp
+++ b/Siv3D/Include/HamFramework/SceneManager.hpp
@@ -29,11 +29,7 @@ namespace s3d
 			return MakeShared<Type>();
 		}
 		
-		template <>
-		inline std::shared_ptr<void> MakeSharedData()
-		{
-			return std::shared_ptr<void>(nullptr);
-		}
+		class UnitType{};
 	}
 
 	/// <summary>
@@ -222,7 +218,7 @@ namespace s3d
 	/// <remarks>
 	/// State にはシーンを区別するキーの型、Data にはシーン間で共有するデータの型を指定します。
 	/// </remarks>
-	template <class State, class Data = void>
+	template <class State, class Data = detail::UnitType>
 	class SceneManager
 	{
 	private:


### PR DESCRIPTION
現状SceneManagerのテンプレート引数Dataのデフォルト値はvoidだが、
ＶＳで実行するとhttps://github.com/Siv3D/OpenSiv3D/blob/master/Siv3D/Include/HamFramework/SceneManager.hpp#L159
で
`error C2182: 'getData': 'void' 型が不適切に使用されています。`
と怒られるため、voidではなく適当な空クラスで置き換えたい

問題が発生するコード
```
# include <Siv3D.hpp>
# include <HamFramework.hpp>
void Main()
{
	using MyApp = SceneManager<String>;
	MyApp manager;
}
```
  