### PR TITLE
SceneManagerのDataのデフォルトの型をvoidから空構造体に変更したい

### DIFF
--- a/Siv3D/include/HamFramework/SceneManager.hpp
+++ b/Siv3D/include/HamFramework/SceneManager.hpp
@@ -29,11 +29,7 @@ namespace s3d
 			return MakeShared<Type>();
 		}
 		
-		template <>
-		inline std::shared_ptr<void> MakeSharedData()
-		{
-			return std::shared_ptr<void>(nullptr);
-		}
+		struct EmptyData{};
 	}
 
 	/// <summary>
@@ -222,7 +218,7 @@ namespace s3d
 	/// <remarks>
 	/// State にはシーンを区別するキーの型、Data にはシーン間で共有するデータの型を指定します。
 	/// </remarks>
-	template <class State, class Data = void>
+	template <class State, class Data = detail::EmptyData>
 	class SceneManager
 	{
 	private:


### PR DESCRIPTION
現状SceneManagerのテンプレート引数Dataのデフォルト値はvoidだが、
VSで実行するとhttps://github.com/Siv3D/OpenSiv3D/blob/ddbfe983378277dce82542dba1e2c336f96d0023/Siv3D/include/HamFramework/SceneManager.hpp#L159
で`error C2182: 'getData': 'void' 型が不適切に使用されています。`
と怒られるため、voidではなく空構造体で置き換えたい

 問題が発生するコード

```
# include <Siv3D.hpp>
# include <HamFramework.hpp>
void Main()
{
	using MyApp = SceneManager<String>;
	MyApp manager;
}
```

関連PR
#232 