### PR TITLE
NamedParameter operator() fix

### DIFF
--- a/Siv3D/include/Siv3D/NamedParameter.hpp
+++ b/Siv3D/include/Siv3D/NamedParameter.hpp
@@ -98,9 +98,9 @@ namespace s3d
 		}
 
 		template <class... Args>
-		constexpr NamedParameter<Tag, std::tuple<Args...>> operator()(const Args&... args) const
+		constexpr NamedParameter<Tag, std::tuple<std::decay_t<Args >...>> operator() (Args&&... args) const
 		{
-			return NamedParameter<Tag, std::tuple<Args...>>(std::make_tuple(args...));
+			return NamedParameter<Tag, std::tuple<std::decay_t<Args >...>>(std::make_tuple(std::forward<Args>(args)...));
 		}
 
 		template <class Type>


### PR DESCRIPTION
 std::decay_t がないため `Arg::code(U"abcd")` とかで コンパイルエラーになる問題を直す
ついでに `operator=()` と同じように引数を `&&` でとるようにする