### PR TITLE
Periodic::Triangleのスペルミス修正

### DIFF
--- a/Siv3D/include/Siv3D/Periodic.hpp
+++ b/Siv3D/include/Siv3D/Periodic.hpp
@@ -41,16 +41,16 @@ namespace s3d
 			return Square0_1(period.count(), t);
 		}
 
-		[[nodiscard]] inline double Tringle0_1(double periodSec, double t = Scene::Time())
+		[[nodiscard]] inline double Triangle0_1(double periodSec, double t = Scene::Time())
 		{
 			const double x = std::fmod(t, periodSec) / (periodSec * 0.5);
 
 			return x <= 1.0 ? x : 2.0 - x;
 		}
 
-		[[nodiscard]] inline double Tringle0_1(const Duration& period, double t = Scene::Time())
+		[[nodiscard]] inline double Triangle0_1(const Duration& period, double t = Scene::Time())
 		{
-			return Tringle0_1(period.count(), t);
+			return Triangle0_1(period.count(), t);
 		}
 
 		[[nodiscard]] inline double Sawtooth0_1(double periodSec, double t = Scene::Time())

--- a/Siv3D/src/Siv3D/Script/Bind/Script_Periodic.cpp
+++ b/Siv3D/src/Siv3D/Script/Bind/Script_Periodic.cpp
@@ -25,7 +25,7 @@ namespace s3d
 		{
 			r = engine->RegisterGlobalFunction("double Sine0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Sine0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
 			r = engine->RegisterGlobalFunction("double Square0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Square0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
-			r = engine->RegisterGlobalFunction("double Tringle0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Tringle0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
+			r = engine->RegisterGlobalFunction("double Triangle0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Triangle0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
 			r = engine->RegisterGlobalFunction("double Sawtooth0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Sawtooth0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
 			r = engine->RegisterGlobalFunction("double Jump0_1(double, double = Scene::Time())", asFUNCTIONPR(Periodic::Jump0_1, (double, double), double), asCALL_CDECL); assert(r >= 0);
 		}


### PR DESCRIPTION
## 概要
Triangleのスペルミスの修正

## 注意点
関数名の修正になるので互換性がありません。