### PR TITLE
Linux版MessageBoxのテキスト描画部分をXftでやるようにした

### DIFF
--- a/Linux/App/CMakeLists.txt
+++ b/Linux/App/CMakeLists.txt
@@ -20,12 +20,14 @@ endif()
 #set(CMAKE_BUILD_TYPE Release)
 
 pkg_check_modules(OPENCV4 REQUIRED opencv4)
+pkg_check_modules(XFT REQUIRED xft)
 
 include_directories(
 	"/usr/include"
 
 	"../../Siv3D/include"
 	"../../Siv3D/include/ThirdParty"
+	${XFT_INCLUDE_DIRS}
 )
 
 set(SOURCE_FILES
@@ -36,6 +38,7 @@ add_executable(Siv3D_App ${SOURCE_FILES})
 
 target_link_libraries(Siv3D_App
 	${OPENCV4_LIBRARIES}
+	${XFT_LIBRARIES}
 	-lOpenGL
 	-lGLEW
 	-lX11
@@ -62,6 +65,7 @@ target_link_libraries(Siv3D_App
 	-lavcodec
 	-lavutil
 	-lswresample
+	-lXft
 
 	${PROJECT_SOURCE_DIR}/../Debug/libSiv3D.a
 )

--- a/Linux/CMakeLists.txt
+++ b/Linux/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 #set(CMAKE_BUILD_TYPE Release)
 
-pkg_check_modules(LIBSIV3D REQUIRED glib-2.0 gobject-2.0 gio-2.0 gl libpng libturbojpeg x11 xi xinerama xcursor xrandr gl glu freetype2 openal opencv4 ogg vorbis)
+pkg_check_modules(LIBSIV3D REQUIRED glib-2.0 gobject-2.0 gio-2.0 gl libpng libturbojpeg x11 xi xinerama xcursor xrandr gl glu freetype2 openal opencv4 ogg vorbis xft)
 include_directories(
 	"/usr/include"
 


### PR DESCRIPTION
#431 

![2019-12-17_13-41](https://user-images.githubusercontent.com/17854286/70965527-466da300-20d3-11ea-84e6-71af51960b95.png)
