### PR TITLE
コンテナの Generate 系関数の改良/追加

### DIFF
--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -102,11 +102,12 @@ namespace s3d
 		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty>>* = nullptr>
 		static Array Generate(const size_type size, Fty generator)
 		{
-			Array new_array(size);
+			Array new_array;
+			new_array.reserve(size);
 
-			for (auto& value : new_array)
+			for (size_type i = 0; i < size; ++i)
 			{
-				value = generator();
+				new_array.push_back(generator());
 			}
 
 			return new_array;
@@ -130,13 +131,12 @@ namespace s3d
 		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty, size_t>>* = nullptr>
 		static Array IndexedGenerate(const size_type size, Fty indexedGenerator)
 		{
-			Array new_array(size);
+			Array new_array;
+			new_array.reserve(size);
 
-			size_t i = 0;
-
-			for (auto& value : new_array)
+			for (size_type i = 0; i < size; ++i)
 			{
-				value = indexedGenerator(i++);
+				new_array.push_back(indexedGenerator(i));
 			}
 
 			return new_array;

--- a/Siv3D/include/Siv3D/Grid.hpp
+++ b/Siv3D/include/Siv3D/Grid.hpp
@@ -57,11 +57,14 @@ namespace s3d
 		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty>>* = nullptr>
 		static Grid Generate(size_type w, size_type h, Fty generator)
 		{
-			Grid new_grid(w, h);
+			Grid new_grid;
+			new_grid.m_data.reserve(w * h);
+			new_grid.m_width  = w;
+			new_grid.m_height = h;
 
-			for (auto& value : new_grid)
+			for (size_type i = 0; i < w * h; ++i)
 			{
-				value = generator();
+				new_grid.m_data.push_back(generator());
 			}
 
 			return new_grid;

--- a/Siv3D/include/Siv3D/Grid.hpp
+++ b/Siv3D/include/Siv3D/Grid.hpp
@@ -70,6 +70,31 @@ namespace s3d
 			return new_grid;
 		}
 
+		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty, Point>>* = nullptr>
+		static Grid IndexedGenerate(const Size& size, Fty indexedGenerator)
+		{
+			return IndexedGenerate(size.x, size.y, indexedGenerator);
+		}
+
+		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty, Point>>* = nullptr>
+		static Grid IndexedGenerate(size_type w, size_type h, Fty indexedGenerator)
+		{
+			Grid new_grid;
+			new_grid.reserve(w, h);
+			new_grid.m_width  = w;
+			new_grid.m_height = h;
+
+			for (size_t y = 0; y < h; ++y)
+			{
+				for (size_t x = 0; x < w; ++x)
+				{
+					new_grid.m_data.push_back(indexedGenerator(Point(x,y)));
+				}
+			}
+
+			return new_grid;
+		}
+
 		/// <summary>
 		/// デフォルトコンストラクタ
 		/// </summary>
@@ -203,6 +228,14 @@ namespace s3d
 		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty>>* = nullptr>
 		Grid(const Size& size, Arg::generator_<Fty> generator)
 			: Grid(Generate<Fty>(size, *generator)) {}
+
+		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty, Point>>* = nullptr>
+		Grid(const size_type w, const size_type h, Arg::indexedGenerator_<Fty> indexedGenerator)
+			: Grid(IndexedGenerate<Fty>(w, h, *indexedGenerator)) {}
+
+		template <class Fty, std::enable_if_t<std::is_invocable_r_v<Type, Fty, Point>>* = nullptr>
+		Grid(const Size& size, Arg::indexedGenerator_<Fty> indexedGenerator)
+			: Grid(Generate<Fty>(size, *indexedGenerator)) {}
 
 		/// <summary>
 		/// コピー代入演算子


### PR DESCRIPTION
Generate 系関数でデフォルトコンストラクタを不要にしました。
また、Grid::IndexedGenerate および対応するコンストラクタを追加しました。

使用例: https://gist.github.com/taotao54321/71dea8f09a7871d38601f4444d014a99