### PR TITLE
gcc10 でのコンパイルエラーを修正

### DIFF
--- a/Siv3D/include/Siv3D/Byte.hpp
+++ b/Siv3D/include/Siv3D/Byte.hpp
@@ -12,6 +12,7 @@
 # pragma once
 # include <type_traits>
 # include <functional>
+# include <iosfwd>
 # include "Fwd.hpp"
 
 namespace s3d

--- a/Siv3D/src/Siv3D/Siv3DEngine.hpp
+++ b/Siv3D/src/Siv3D/Siv3DEngine.hpp
@@ -11,6 +11,7 @@
 
 # pragma once
 # include <cassert>
+# include <cstddef>
 # include <tuple>
 
 namespace s3d


### PR DESCRIPTION
Linux 版を gcc10 でコンパイルすると、いくつかの型が見つからずエラーになるようです。
Debian testing 上の g++ 10.2.1 で問題を確認しました。

ヘッダの include 漏れが原因と思われるので、必要な `#include` を追加したところコンパイルが通りました。

よろしければご検討をお願いいたします。