### PR TITLE
[共通] PPM 画像のエンコード不具合 #591 の修正

### DIFF
--- a/Siv3D/src/Siv3D/ImageFormat/PPM/PPMDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/PPM/PPMDecoder.cpp
@@ -303,6 +303,10 @@ namespace s3d
 				return Image();
 			}
 
+			const int64 pixelDataBytes = size.x * size.y * byteSizeOfPixel;
+
+			reader.setPos(reader.size() - pixelDataBytes);
+
 			Image image(size);
 
 			uint8* data = image.dataAsUint8();
@@ -333,13 +337,17 @@ namespace s3d
 		{
 			const uint32 maxValue = ReadNum(reader);
 
-			const uint32 byteSizeOfPixel = RequiredBytes(maxValue);
+			const uint32 byteSizeOfColor = RequiredBytes(maxValue);
 
-			if (byteSizeOfPixel != 1)
+			if (byteSizeOfColor != 1)
 			{
 				//LOG_ERROR(L"PNM形式では輝度の最大値は255までしか扱えません");
 				return Image();
 			}
+
+			const int64 pixelDataBytes = size.x * size.y * byteSizeOfColor * 3;
+
+			reader.setPos(reader.size() - pixelDataBytes);
 
 			Image image(size);
 

--- a/Siv3D/src/Siv3D/ImageFormat/PPM/PPMEncoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/PPM/PPMEncoder.cpp
@@ -154,14 +154,14 @@ namespace s3d
 					writer.write(c);
 				}
 
-				uint8 c = 0;
-				for (uint8 i = 128; x < image.width(); ++x, i >>= 1)
+				if (x < image.width())
 				{
-					c += binarize(image[y][x]) ? i : 0;
-				}
+					uint8 c = 0;
+					for (uint8 i = 128; x < image.width(); ++x, i >>= 1)
+					{
+						c += binarize(image[y][x]) ? i : 0;
+					}
 
-				if (1 <= image.width())
-				{
 					writer.write(c);
 				}
 			}


### PR DESCRIPTION

PPM 形式の画像の保存、読み込み処理における以下の不具合を修正しました
- P4 形式の保存で画像の横幅が8の倍数のとき不正なデータが出力される
- P5, P6 形式の読み込みでピクセルの値によっては読み込みに失敗する場合がある