### PR TITLE
Catalina/Xcode12.2でのビルドのエラー

### DIFF
--- a/Siv3D/include/Siv3D/Date.hpp
+++ b/Siv3D/include/Siv3D/Date.hpp
@@ -126,7 +126,6 @@ namespace s3d
 
 	# if __cpp_impl_three_way_comparison
 
-		[[nodiscard]]
 		friend constexpr auto operator <=>(const Date&, const Date&) = default;
 
 	# else

--- a/Siv3D/include/Siv3D/DateTime.hpp
+++ b/Siv3D/include/Siv3D/DateTime.hpp
@@ -128,7 +128,6 @@ namespace s3d
 
 	# if __cpp_impl_three_way_comparison
 
-		[[nodiscard]]
 		friend constexpr auto operator <=>(const DateTime&, const DateTime&) = default;
 
 	# else


### PR DESCRIPTION
Mac0S Catalina 10.15.7 / Xcode 12.2 でのv0.6ビルド時に起きたエラーの解決方法です
Date.hppの129行目、DateTime.hppの131行目の[[discard]]を削除しました。その時のエラーを載せておきます。

```Log
Build target Siv3D of project OpenSiv3D with configuration Debug

CompileC /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Objects-normal/x86_64/ZIPReaderDetail.o /Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/src/Siv3D/ZIPReader/ZIPReaderDetail.cpp normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'Siv3D' from project 'OpenSiv3D')
    cd /Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/macOS
    export LANG\=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++ -target x86_64-apple-macos10.14 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -std\=c++2a -stdlib\=libc++ -fmodules -fmodules-cache-path\=/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -fmodules-prune-interval\=86400 -fmodules-prune-after\=345600 -fbuild-session-file\=/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror\=non-modular-include-in-framework-module -Wno-trigraphs -fpascal-strings -O0 -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror\=return-type -Wunreachable-code -Wquoted-include-in-framework-header -Werror\=deprecated-objc-isa-usage -Werror\=objc-root-class -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wno-float-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wshorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -DDEBUG\=1 -D__MACOSX_CORE__ -D_GLFW_COCOA -DGLEW_STATIC -DGLEW_NO_GLU -D_UNICODE -DMSDFGEN_USE_CPP11 -DWITH_MINIAUDIO -DWITH_NOSOUND -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -g -Wno-sign-conversion -Winfinite-recursion -Wmove -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wrange-loop-analysis -Wno-semicolon-before-method-body -index-store-path /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Index/DataStore -iquote /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Siv3D-generated-files.hmap -I/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Siv3D-own-target-headers.hmap -I/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Siv3D-all-target-headers.hmap -iquote /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Siv3D-project-headers.hmap -I/Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/lib/macOS/include -I../Siv3D/include -I../Siv3D/include/ThirdParty -I../Siv3D/src -I../Siv3D/src/Siv3D-Platform/macOS -I../Siv3D/src/Siv3D-Platform/macOS_Linux -I../Siv3D/src/Siv3D-Platform/OpenGL4 -I../Siv3D/src/ThirdParty -I../Siv3D/src/ThirdParty/freetype -I../Siv3D/src/ThirdParty-prebuilt -I../Dependencies/boost_1_73_0 -I/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/DerivedSources-normal/x86_64 -I/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/DerivedSources/x86_64 -I/Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/DerivedSources -Wall -Wextra -F/Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/lib/macOS -fvisibility-inlines-hidden -MMD -MT dependencies -MF /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Objects-normal/x86_64/ZIPReaderDetail.d --serialize-diagnostics /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Objects-normal/x86_64/ZIPReaderDetail.dia -c /Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/src/Siv3D/ZIPReader/ZIPReaderDetail.cpp -o /Users/MY_USER_NAME/Library/Developer/Xcode/DerivedData/OpenSiv3D-gvndorrlldkrlddmuekbayfzyqua/Build/Intermediates.noindex/OpenSiv3D.build/Debug/Siv3D.build/Objects-normal/x86_64/ZIPReaderDetail.o

In file included from /Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/src/Siv3D/ZIPReader/ZIPReaderDetail.cpp:13:
In file included from ../Siv3D/include/Siv3D/FileSystem.hpp:16:
In file included from ../Siv3D/include/Siv3D/DateTime.hpp:14:
../Siv3D/include/Siv3D/Date.hpp:129:3: error: an attribute list cannot appear here
                [[nodiscard]]
                ^~~~~~~~~~~~~
In file included from /Users/MY_USER_NAME/Applications/OpenSiv3Dv0_4_3/examples/OpenSiv3D-6_master/Siv3D/src/Siv3D/ZIPReader/ZIPReaderDetail.cpp:13:
In file included from ../Siv3D/include/Siv3D/FileSystem.hpp:16:
../Siv3D/include/Siv3D/DateTime.hpp:131:3: error: an attribute list cannot appear here
                [[nodiscard]]
                ^~~~~~~~~~~~~
2 errors generated.
```

(Pull Requestは今回これが初めてなのですが、こんな形式で大丈夫ですか？)