### PR TITLE
Web版 更新

### DIFF
--- a/Siv3D/include/Siv3D/Clipboard.hpp
+++ b/Siv3D/include/Siv3D/Clipboard.hpp
@@ -51,4 +51,11 @@ namespace s3d
 		/// @brief クリップボードの内容を消去します。
 		void Clear();
 	}
+
+# if SIV3D_PLATFORM(WEB)
+	namespace Platform::Web::Clipboard 
+	{
+		std::future<String> GetText();
+	}
+# endif
 }

--- a/Siv3D/include/Siv3D/Dialog.hpp
+++ b/Siv3D/include/Siv3D/Dialog.hpp
@@ -71,7 +71,7 @@ namespace s3d
  	namespace Platform::Web::Dialog 
 	{
 		[[nodiscard]]
-        std::future<Optional<FilePath>> OpenFile(const Array<FileFilter>& filters = {}, FilePathView defaultPath = U"", StringView title = U"");
+		std::future<Optional<FilePath>> OpenFile(const Array<FileFilter>& filters = {}, FilePathView defaultPath = U"", StringView title = U"");
 
 		[[nodiscard]]
 		std::future<Array<FilePath>> OpenFiles(const Array<FileFilter>& filters = {}, FilePathView defaultPath = U"", StringView title = U"");

--- a/Siv3D/include/Siv3D/Dialog.hpp
+++ b/Siv3D/include/Siv3D/Dialog.hpp
@@ -64,4 +64,41 @@ namespace s3d
 		[[nodiscard]]
 		Optional<FilePath> SaveWave(FilePathView defaultPath = U"", StringView title = U"");
 	}
+
+	
+# if SIV3D_PLATFORM(WEB)
+
+ 	namespace Platform::Web::Dialog 
+	{
+		[[nodiscard]]
+        std::future<Optional<FilePath>> OpenFile(const Array<FileFilter>& filters = {}, FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Array<FilePath>> OpenFiles(const Array<FileFilter>& filters = {}, FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Image> OpenImage(FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Texture> OpenTexture(FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Texture> OpenTexture(TextureDesc desc, FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Wave> OpenWave(FilePathView defaultPath = U"", StringView title = U"");
+
+		[[nodiscard]]
+		std::future<Audio> OpenAudio(FilePathView defaultPath = U"", StringView title = U"");
+
+		/// @brief ダイアログから音声ファイルを選択し、ストリーミング再生する Audio を作成します。
+		/// @param f `Audio::Stream`
+		/// @param defaultPath ダイアログのデフォルトディレクトリ
+		/// @param title ダイアログのタイトル
+		/// @return 作成した音声。ファイルが選択されなかった場合は空の Audio
+		[[nodiscard]]
+		std::future<Audio> OpenAudio(Audio::FileStreaming f, FilePathView defaultPath = U"", StringView title = U"");
+    }
+
+# endif
 }

--- a/Siv3D/include/Siv3D/SIMD.hpp
+++ b/Siv3D/include/Siv3D/SIMD.hpp
@@ -23,6 +23,9 @@
 # include <ThirdParty/simde/x86/sse4.1.h>
 # include <ThirdParty/simde/x86/sse4.2.h>
 
+# define _mm_malloc(__size, __align) memalign((__align), (__size))
+# define _mm_free free
+
 # else
 
 # if __has_include(<xmmintrin.h>)

--- a/Siv3D/include/Siv3D/TextInput.hpp
+++ b/Siv3D/include/Siv3D/TextInput.hpp
@@ -52,5 +52,14 @@ namespace s3d
 			const ColorF& textColor = ColorF{ 0.0 });
 	}
 
+# elif SIV3D_PLATFORM(WEB)
+
+	namespace Platform::Web::TextInput
+	{
+		void RequestEnableIME();
+		
+		void RequestDisableIME();
+	}
+
 # endif
 }

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Clipboard/CClipboard.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Clipboard/CClipboard.cpp
@@ -16,6 +16,17 @@
 
 namespace s3d
 {
+	namespace detail
+	{
+		__attribute__((import_name("siv3dSetClipboardText")))
+		extern void siv3dSetClipboardText(const char* text);
+
+		using siv3dGetClipboardTextCallBack = void(*)(char* text, void* promise);
+
+		__attribute__((import_name("siv3dGetClipboardText")))
+		extern void siv3dGetClipboardText(siv3dGetClipboardTextCallBack, void*);
+	}
+
 	CClipboard::CClipboard() {}
 
 	CClipboard::~CClipboard()
@@ -26,8 +37,6 @@ namespace s3d
 	void CClipboard::init()
 	{
 		LOG_SCOPED_TRACE(U"CClipboard::init()");
-
-		m_window = static_cast<GLFWwindow*>(SIV3D_ENGINE(Window)->getHandle());
 	}
 
 	bool CClipboard::hasChanged()
@@ -38,9 +47,12 @@ namespace s3d
 
 	bool CClipboard::getText(String& text)
 	{
-		if (m_window)
+		detail::siv3dGetClipboardText(&OnGetClipboardText, this);
+
+		if (m_clibboardTexts.size() > 0)
 		{
-			text = Unicode::Widen(::glfwGetClipboardString(m_window));
+			text = m_clibboardTexts.front();
+			m_clibboardTexts.pop_front();
 		}
 		else
 		{
@@ -70,7 +82,7 @@ namespace s3d
 
 	void CClipboard::setText(const String& text)
 	{
-		::glfwSetClipboardString(m_window, text.narrow().c_str());
+		detail::siv3dSetClipboardText(text.narrow().c_str());
 	}
 
 	void CClipboard::setImage(const Image& image)
@@ -81,5 +93,45 @@ namespace s3d
 	void CClipboard::clear()
 	{
 		// [Siv3D ToDo]
+	}
+
+	void CClipboard::OnGetClipboardText(char* text, void* userData)
+	{
+		auto& clipboard = *static_cast<CClipboard*>(userData);
+
+		if (text)
+		{
+			clipboard.m_clibboardTexts << Unicode::FromUTF8(text);
+		}
+	}
+
+	namespace Platform::Web::Clipboard 
+	{
+		namespace detail
+		{
+			void OnGetClipboardText(char* text, void* userData)
+			{
+				auto promise = static_cast<std::promise<s3d::String>*>(userData);
+
+				if (text)
+				{
+					promise->set_value(Unicode::Widen(text));
+				}
+				else
+				{
+					promise->set_value(U"");
+				}
+			}
+		}
+
+		std::future<String> GetText()
+		{
+			auto p = new std::promise<s3d::String>();
+			auto result_future = p->get_future();
+
+			s3d::detail::siv3dGetClipboardText(&detail::OnGetClipboardText, p);
+			
+			return result_future;
+		}
 	}
 }

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Clipboard/CClipboard.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Clipboard/CClipboard.hpp
@@ -41,6 +41,8 @@ namespace s3d
 
 	private:
 
-		GLFWwindow* m_window = nullptr;
+		static void OnGetClipboardText(char* text, void* userData);
+
+		Array<String> m_clibboardTexts;
 	};
 }

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Dialog/SivDialog_Web.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Dialog/SivDialog_Web.cpp
@@ -10,11 +10,20 @@
 //-----------------------------------------------
 
 # include <Siv3D/Dialog.hpp>
+# include <Siv3D/FileSystem.hpp>
+# include <Siv3D/Wave.hpp>
+# include <Siv3D/Audio.hpp>
 
 namespace s3d
 {
 	namespace Dialog
 	{
+		namespace detail
+		{
+			__attribute__((import_name("siv3dSaveDialog")))
+			extern void siv3dSaveDialog(const char* fileName);
+		}
+
 		Optional<FilePath> OpenFile(const Array<FileFilter>& filters, const FilePathView defaultPath, const StringView title)
 		{
 			// [Siv3D ToDo]
@@ -29,14 +38,122 @@ namespace s3d
 
 		Optional<FilePath> SaveFile(const Array<FileFilter>& filters, const FilePathView defaultPath, const StringView title)
 		{
-			// [Siv3D ToDo]
-			return (none);
+			const auto fileName = FileSystem::FileName(defaultPath);
+			detail::siv3dSaveDialog(fileName.narrow().c_str());
+			
+			return FilePath(U"/dev/save");
 		}
 
 		Optional<FilePath> SelectFolder(const FilePathView defaultPath, const StringView title)
 		{
 			// [Siv3D ToDo]
 			return (none);
+		}
+	}
+
+	namespace Platform::Web::Dialog
+	{
+		namespace detail
+		{
+			String TransformFileFilters(const Array<FileFilter>& filters) 
+			{
+				return filters
+					.map([](const FileFilter& f) 
+					{
+						return f.patterns
+							.map([](const String& p) 
+							{
+								return p.count(U'/') == 1 ? p : U"." + p;
+							})
+							.join(U",", U"", U"");
+					})
+					.join(U",", U"", U"");
+			}
+
+			template <class T>
+			using siv3dOpenDialogCallback = void (*)(char*, std::promise<T>*);
+
+			template <class T>
+			__attribute__((import_name("siv3dOpenDialog")))
+			void siv3dOpenDialogImpl(const char*, siv3dOpenDialogCallback<T>, std::promise<T>*);
+
+			template <class T>
+			void OnOpenFileDialogClosed(char* fileName, std::promise<T>* result)
+			{
+				if (fileName == 0)
+				{
+					result->set_value(T{});
+				}
+				else
+				{
+					auto path = Unicode::Widen(fileName);
+					result->set_value(T{path});
+				}
+
+				delete fileName;
+				delete result;
+			}
+
+			void OnOpenAudioDialogClosed(char* fileName, std::promise<Audio>* result)
+			{
+				if (fileName == 0)
+				{
+					result->set_value(Audio{});
+				}
+				else
+				{
+					auto path = Unicode::Widen(fileName);
+					// AudioProcessing::DecodeAudioFromFile(path, std::move(*result));
+				}
+
+				delete fileName;
+				delete result;
+			}
+
+			template <class T>
+			std::future<T> siv3dOpenDialog(const Array<FileFilter>& filters, siv3dOpenDialogCallback<T> callback = &OnOpenFileDialogClosed<T>)
+			{
+				const auto filter = TransformFileFilters(filters);
+
+				auto result = new std::promise<T>();
+				auto result_future = result->get_future();
+				
+				siv3dOpenDialogImpl<T>(filter.narrow().c_str(), callback, result);
+				
+				return result_future;
+			}
+		}
+
+		std::future<Optional<FilePath>> OpenFile(const Array<FileFilter>& filters, FilePathView defaultPath, StringView)
+		{
+			return detail::siv3dOpenDialog<Optional<FilePath>>(filters);
+		}
+
+
+
+		std::future<Image> OpenImage(FilePathView defaultPath, StringView title)
+		{
+			return detail::siv3dOpenDialog<Image>({ FileFilter::AllImageFiles() });
+		}
+
+		std::future<Texture> OpenTexture(FilePathView defaultPath, StringView title)
+		{
+			return detail::siv3dOpenDialog<Texture>({ FileFilter::AllImageFiles() });
+		}
+
+		std::future<Texture> OpenTexture(const TextureDesc desc, FilePathView defaultPath, StringView title)
+		{
+			return detail::siv3dOpenDialog<Texture>({ FileFilter::AllImageFiles() });
+		}
+
+		std::future<Wave> OpenWave(FilePathView defaultPath, StringView title)
+		{
+			return detail::siv3dOpenDialog<Wave>({ FileFilter::AllAudioFiles() });
+		}
+
+		std::future<Audio> OpenAudio(FilePathView defaultPath, StringView title)
+		{
+			return detail::siv3dOpenDialog<Audio>({ FileFilter::AllAudioFiles() }, &detail::OnOpenAudioDialogClosed);
 		}
 	}
 }

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/PseudoThread/PseudoThread.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/PseudoThread/PseudoThread.hpp
@@ -52,6 +52,7 @@ namespace s3d
             if (bool shouldContinue = PseudoThreadExecute(*__p.get(), _Index()); not shouldContinue) 
             {
                 ::emscripten_clear_interval(nativeHandle->m_IntervalID);
+                nativeHandle->m_IntervalID = 0;
                 return;          
             }
 
@@ -112,7 +113,7 @@ namespace s3d
 
         bool joinable() const
         {
-            return false;
+            return m_NativeHandle && m_NativeHandle->m_IntervalID != 0;
         }
 
         void join()

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
@@ -33,6 +33,7 @@
 # include <Siv3D/AudioDecoder/IAudioDecoder.hpp>
 # include <Siv3D/AudioEncoder/IAudioEncoder.hpp>
 # include <Siv3D/FFT/IFFT.hpp>
+# include <Siv3D/Audio/IAudio.hpp>
 # include <Siv3D/TextToSpeech/ITextToSpeech.hpp>
 # include <Siv3D/Renderer/IRenderer.hpp>
 # include <Siv3D/Renderer2D/IRenderer2D.hpp>
@@ -88,6 +89,7 @@ namespace s3d
 		SIV3D_ENGINE(AudioDecoder)->init();
 		SIV3D_ENGINE(AudioEncoder)->init();
 		SIV3D_ENGINE(FFT)->init();
+		SIV3D_ENGINE(Audio)->init();
 		SIV3D_ENGINE(TextToSpeech)->init();
 		SIV3D_ENGINE(Renderer)->init();
 		SIV3D_ENGINE(Renderer2D)->init();

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
@@ -57,6 +57,9 @@ namespace s3d
 
 		__attribute__((import_name("siv3dStopUserActionHook")))
 		extern void siv3dStopUserActionHook();
+
+		__attribute__((import_name("siv3dInitDialog")))
+		extern void siv3dInitDialog();
 	}
 
 	CSystem::CSystem()
@@ -111,6 +114,7 @@ namespace s3d
 		SIV3D_ENGINE(Effect)->init();
 
 		detail::siv3dStartUserActionHook();
+		detail::siv3dInitDialog();
 	}
 
 	bool CSystem::update()

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
@@ -50,6 +50,15 @@
 
 namespace s3d
 {
+	namespace detail
+	{
+		__attribute__((import_name("siv3dStartUserActionHook")))
+		extern void siv3dStartUserActionHook();
+
+		__attribute__((import_name("siv3dStopUserActionHook")))
+		extern void siv3dStopUserActionHook();
+	}
+
 	CSystem::CSystem()
 	{
 
@@ -58,6 +67,8 @@ namespace s3d
 	CSystem::~CSystem()
 	{
 		LOG_SCOPED_TRACE(U"CSystem::~CSystem()");
+
+		detail::siv3dStopUserActionHook();
 
 		SystemMisc::Destroy();
 		SystemLog::Final();
@@ -98,6 +109,8 @@ namespace s3d
 		SIV3D_ENGINE(GUI)->init();
 		SIV3D_ENGINE(Print)->init();
 		SIV3D_ENGINE(Effect)->init();
+
+		detail::siv3dStartUserActionHook();
 	}
 
 	bool CSystem::update()

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/TextInput/CTextInput.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/TextInput/CTextInput.hpp
@@ -70,7 +70,11 @@ namespace s3d
 		Stopwatch m_tabPress;
 		
 		Stopwatch m_backSpacePress;
+
+		bool m_requestedEnablingIME = false;
+
+		bool m_requestedDisablingIME = false;
 		
-		static void OnCharacterInput(GLFWwindow*, uint32 codePoint);
+		static void OnCharacterInput(uint32 codePoint);
 	};
 }

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/FrameBufferUnpacker.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/FrameBufferUnpacker.hpp
@@ -1,0 +1,99 @@
+//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include <GLES3/gl3.h>
+
+namespace s3d
+{
+    struct FrameBufferUnpacker
+    {
+        FrameBufferUnpacker()
+        {
+            ::glGenBuffers(1, &m_pixelBuffer);
+        }
+
+        ~FrameBufferUnpacker()
+        {
+            if (m_pixelReadSync)
+            {
+                ::glDeleteSync(m_pixelReadSync);
+            }
+
+            ::glDeleteBuffers(1, &m_pixelBuffer);
+        }
+
+        void resize(Size bufferSize)
+        {
+            m_BufferSize = bufferSize;
+
+            ::glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pixelBuffer);
+            ::glBufferData(GL_PIXEL_PACK_BUFFER, bufferSize.x * bufferSize.y * 4, nullptr, GL_DYNAMIC_READ);
+        }
+
+        bool hasFinishedUnpack() const
+        {
+            if (not m_pixelReadSync)
+            {
+                return false;	
+            }
+
+            auto waitResult = ::glClientWaitSync(m_pixelReadSync, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+            auto unpackFinished = waitResult == GL_CONDITION_SATISFIED || waitResult == GL_ALREADY_SIGNALED;
+
+            return unpackFinished;
+        }
+
+        void startUnpack(GLuint frameBuffer)
+        {
+            ::glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+            ::glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pixelBuffer);
+            {
+                ::glPixelStorei(0x9240 /*GL_UNPACK_FLIP_Y_WEBGL*/, GL_TRUE);
+                ::glReadPixels(0, 0, m_BufferSize.x, m_BufferSize.y, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+                ::glPixelStorei(0x9240 /*GL_UNPACK_FLIP_Y_WEBGL*/, GL_FALSE);				
+            }
+            ::glBindFramebuffer(GL_FRAMEBUFFER, 0);
+            ::glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+            if (m_pixelReadSync)
+            {
+                ::glDeleteSync(m_pixelReadSync);
+            }
+
+            m_pixelReadSync = ::glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+        }
+
+        void readPixels(Image& image) const
+        {
+            if (not hasFinishedUnpack())
+            {
+                return;
+            }
+
+            image.resize(m_BufferSize);
+
+            ::glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pixelBuffer);
+            {	
+                ::glGetBufferSubData(GL_PIXEL_PACK_BUFFER, 0, m_BufferSize.x * m_BufferSize.y * 4, image.data());	
+            }
+            ::glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+        }
+
+    private:
+
+        Size m_BufferSize = Size(0, 0);
+
+        GLuint m_pixelBuffer = 0;
+
+        GLsync m_pixelReadSync = nullptr;
+    };
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
@@ -1,0 +1,125 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# include <Siv3D/Webcam.hpp>
+# include <Siv3D/Webcam/WebcamDetail.hpp>
+
+namespace s3d
+{
+	Webcam::Webcam()
+		: pImpl{ std::make_shared<WebcamDetail>() } {}
+
+	Webcam::Webcam(const uint32 cameraIndex, const StartImmediately startImmediately)
+		: Webcam{}
+	{
+		if (not pImpl->open(cameraIndex))
+		{
+			return;
+		}
+
+		if (startImmediately)
+		{
+			pImpl->start();
+		}
+	}
+
+	Webcam::Webcam(const uint32 cameraIndex, const Size& targetResolution, const StartImmediately startImmediately)
+		: Webcam{}
+	{
+		if (not pImpl->open(cameraIndex))
+		{
+			return;
+		}
+
+		pImpl->setResolution(targetResolution);
+
+		if (startImmediately)
+		{
+			pImpl->start();
+		}
+	}
+	
+	Webcam::~Webcam()
+	{
+		// do nothing
+	}
+
+	Optional<Webcam::Permission> Webcam::getPermission() const
+	{
+		// [Siv3D ToDo]
+		return Webcam::Permission::Allowed;
+	}
+
+	bool Webcam::open(const uint32 cameraIndex)
+	{
+		return pImpl->open(cameraIndex);
+	}
+
+	void Webcam::close()
+	{
+		pImpl->close();
+	}
+
+	bool Webcam::isOpen() const
+	{
+		return pImpl->isOpen();
+	}
+	
+	Webcam::operator bool() const
+	{
+		return isOpen();
+	}
+
+	bool Webcam::start()
+	{
+		return pImpl->start();
+	}
+
+	bool Webcam::isActive() const
+	{
+		return pImpl->isActive();
+	}
+
+	uint32 Webcam::cameraIndex() const
+	{
+		return pImpl->cameraIndex();
+	}
+
+	Size Webcam::getResolution() const
+	{
+		return pImpl->getResolution();
+	}
+
+	bool Webcam::setResolution(const int32 width, const int32 height)
+	{
+		return pImpl->setResolution(Size{ width, height });
+	}
+
+	bool Webcam::setResolution(const Size resolution)
+	{
+		return pImpl->setResolution(resolution);
+	}
+
+	bool Webcam::hasNewFrame() const
+	{
+		return pImpl->hasNewFrame();
+	}
+
+	bool Webcam::getFrame(Image& image)
+	{
+		return pImpl->getFrame(image);
+	}
+
+	bool Webcam::getFrame(DynamicTexture& texture)
+	{
+		return pImpl->getFrame(texture);
+	}
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
@@ -34,12 +34,12 @@ namespace s3d
 	Webcam::Webcam(const uint32 cameraIndex, const Size& targetResolution, const StartImmediately startImmediately)
 		: Webcam{}
 	{
+		pImpl->setResolution(targetResolution);
+
 		if (not pImpl->open(cameraIndex))
 		{
 			return;
 		}
-
-		pImpl->setResolution(targetResolution);
 
 		if (startImmediately)
 		{

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.cpp
@@ -1,0 +1,144 @@
+//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# include <Siv3D/System.hpp>
+# include <Siv3D/EngineLog.hpp>
+# include "WebCameraCapture.hpp"
+
+namespace s3d
+{
+	namespace detail
+	{
+		using siv3dOpenCameraCallback = void(*)(GLuint elementID, void* userData);
+		using siv3dPlayVideoCallback = void(*)(void* userData);
+
+		__attribute__((import_name("siv3dOpenCamera")))
+		extern void siv3dOpenCamera(int width, int height, siv3dOpenCameraCallback callback, void* callbackArg);
+
+		__attribute__((import_name("siv3dQueryVideoPlaybackedTime")))
+		extern double siv3dQueryVideoPlaybackedTime(GLuint elementID);
+
+		__attribute__((import_name("siv3dCaptureVideoFrame")))
+		extern void siv3dCaptureVideoFrame(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLuint elementID);
+
+		__attribute__((import_name("siv3dPlayVideo")))
+		extern void siv3dPlayVideo(GLuint elementID);
+
+		__attribute__((import_name("siv3dStopVideo")))
+		extern void siv3dStopVideo(GLuint elementID);
+
+		__attribute__((import_name("siv3dDestroyVideo")))
+		extern void siv3dDestroyVideo(GLuint elementID);
+
+    }
+
+    WebCameraCapture::WebCameraCapture()
+    {
+        ::glGenTextures(1, &m_videoBufferTexture);
+        ::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+        {
+            ::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            ::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        }
+        ::glBindTexture(GL_TEXTURE_2D, 0);
+
+        ::glGenFramebuffers(1, &m_videoBufferFrameBuffer);
+    }
+
+    WebCameraCapture::~WebCameraCapture()
+    {
+        release();
+
+        ::glDeleteTextures(1, &m_videoBufferTexture);
+        ::glDeleteFramebuffers(1, &m_videoBufferFrameBuffer);
+    }
+
+    bool WebCameraCapture::open()
+    {
+        detail::siv3dOpenCamera(m_captureResolution.x, m_captureResolution.y, &OnOpened, this);
+        return true;
+    }
+
+    void WebCameraCapture::stop()
+    {
+        detail::siv3dStopVideo(m_videoElementID);
+    }
+
+    void WebCameraCapture::release()
+    {
+        detail::siv3dDestroyVideo(m_videoElementID);
+        m_videoElementID = 0;
+    }
+
+    void WebCameraCapture::setResolution(const Size& resolution)
+    {
+        m_captureResolution = resolution;
+    }
+
+    bool WebCameraCapture::grab()
+    {
+        auto currentPlaybackedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
+        return (currentPlaybackedTime - m_lastFrameCapturedTime) > 0.001;
+    }
+
+    GLuint WebCameraCapture::capture()
+    {
+        m_lastFrameCapturedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
+
+        ::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+        {
+            detail::siv3dCaptureVideoFrame(
+                GL_TEXTURE_2D, 0, GL_RGBA8, 
+                m_captureResolution.x, m_captureResolution.y, 
+                0, GL_RGBA, GL_UNSIGNED_BYTE, m_videoElementID);
+        }
+        ::glBindTexture(GL_TEXTURE_2D, 0);
+
+        return m_videoBufferFrameBuffer;
+    }
+
+    bool WebCameraCapture::isOpened() const
+    {
+        return m_videoElementID != 0;
+    }
+
+    void WebCameraCapture::OnOpened(GLuint elementID, void* userData)
+    {
+        auto& webcam = *static_cast<WebCameraCapture*>(userData);
+
+        webcam.m_videoElementID = elementID;
+        webcam.prepareBuffers();
+
+        detail::siv3dPlayVideo(elementID);
+    } 
+
+    void WebCameraCapture::prepareBuffers()
+    {
+        ::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+        {
+            ::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, m_captureResolution.x, m_captureResolution.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        }
+        ::glBindTexture(GL_TEXTURE_2D, 0);
+
+        ::glBindFramebuffer(GL_FRAMEBUFFER, m_videoBufferFrameBuffer);
+        {
+            ::glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_videoBufferTexture, 0);
+
+            if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) 
+            {
+                LOG_ERROR(U"Incomplete Framebuffer");
+                return;
+            }
+        }
+        ::glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.cpp
@@ -9,7 +9,7 @@
 //
 //-----------------------------------------------
 
-# include <Siv3D/System.hpp>
+# include <Siv3D/PointVector.hpp>
 # include <Siv3D/EngineLog.hpp>
 # include "WebCameraCapture.hpp"
 

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.hpp
@@ -11,7 +11,6 @@
 
 # pragma once
 # include <Siv3D/Fwd.hpp>
-# include <Siv3D/Point.hpp>
 # include <GLES3/gl3.h>
 
 namespace s3d

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.hpp
@@ -1,0 +1,57 @@
+//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include <Siv3D/Fwd.hpp>
+# include <Siv3D/Point.hpp>
+# include <GLES3/gl3.h>
+
+namespace s3d
+{
+    class WebCameraCapture
+    {
+    public:
+
+        WebCameraCapture();
+
+        ~WebCameraCapture();
+
+        bool open();
+
+        void stop();
+
+        void release();
+    
+        void setResolution(const Size& resolution);
+
+        bool grab();
+    
+        GLuint capture();
+
+        bool isOpened() const;
+
+    private:
+
+        static void OnOpened(GLuint elementID, void* userData);
+
+        void prepareBuffers();
+
+        Size m_captureResolution = { 0, 0 };
+
+        GLuint m_videoElementID = 0;
+
+        GLuint m_videoBufferTexture = 0;
+
+        GLuint m_videoBufferFrameBuffer = 0;
+
+        double m_lastFrameCapturedTime = 0.0;
+    };
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
@@ -1,0 +1,272 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# include <Siv3D/System.hpp>
+# include <Siv3D/EngineLog.hpp>
+# include "WebcamDetail.hpp"
+
+namespace s3d
+{
+	namespace detail
+	{
+		void CopyFrame(const cv::Mat_<cv::Vec3b>& src, Image& dst)
+		{
+			const size_t num_pixels = dst.num_pixels();
+			const uint8* pSrc = src.data;
+			uint8* pDst = dst.dataAsUint8();
+
+			if (num_pixels % 4 == 0)
+			{
+				const size_t count = (num_pixels / 4);
+
+				for (size_t i = 0; i < count; ++i)
+				{
+					pDst[2] = pSrc[0];
+					pDst[1] = pSrc[1];
+					pDst[0] = pSrc[2];
+
+					pDst[6] = pSrc[3];
+					pDst[5] = pSrc[4];
+					pDst[4] = pSrc[5];
+
+					pDst[10] = pSrc[6];
+					pDst[9] = pSrc[7];
+					pDst[8] = pSrc[8];
+
+					pDst[14] = pSrc[9];
+					pDst[13] = pSrc[10];
+					pDst[12] = pSrc[11];
+
+					pDst += 16;
+					pSrc += 12;
+				}
+			}
+			else
+			{
+				for (size_t i = 0; i < num_pixels; ++i)
+				{
+					pDst[2] = pSrc[0];
+					pDst[1] = pSrc[1];
+					pDst[0] = pSrc[2];
+
+					pDst += 4;
+					pSrc += 3;
+				}
+			}
+		}
+	}
+
+	Webcam::WebcamDetail::WebcamDetail() {}
+
+	Webcam::WebcamDetail::~WebcamDetail()
+	{
+		close();
+	}
+
+	bool Webcam::WebcamDetail::open(const uint32 cameraIndex)
+	{
+		LOG_SCOPED_TRACE(U"Webcam::WebcamDetail::open(cameraIndex = {})"_fmt(cameraIndex));
+
+		close();
+
+		if (not m_capture.open(static_cast<int32>(cameraIndex)))
+		{
+			LOG_ERROR(U"cv::VideoCapture::oepn({}) failed"_fmt(cameraIndex));
+			
+			return false;
+		}
+
+		LOG_INFO(U"cv::VideoCapture::oepn({}) succeeded"_fmt(cameraIndex));
+
+		m_cameraIndex = cameraIndex;
+
+		{
+			m_captureResolution.set(
+				static_cast<int32>(m_capture.get(cv::CAP_PROP_FRAME_WIDTH)),
+				static_cast<int32>(m_capture.get(cv::CAP_PROP_FRAME_HEIGHT)));
+			
+			m_image = Image{ m_captureResolution, Color{ 255 } };
+		}
+
+		return true;
+	}
+
+	void Webcam::WebcamDetail::close()
+	{
+		if (not m_capture.isOpened())
+		{
+			return;
+		}
+
+		if (not m_thread.joinable())
+		{
+			return;
+		}
+
+		m_abort = true;
+
+		m_thread.join();
+		{
+			m_abort = false;
+			m_capture.release();
+			m_cameraIndex = 0;
+			m_newFrameCount = 0;
+			m_captureResolution.set(0, 0);
+		}
+	}
+
+	bool Webcam::WebcamDetail::isOpen()
+	{
+		return m_capture.isOpened();
+	}
+
+	bool Webcam::WebcamDetail::start()
+	{
+		if (not m_capture.isOpened())
+		{
+			return false;
+		}
+
+		// すでに start 後の場合は何もしない
+		if (m_thread.joinable())
+		{
+			return true;
+		}
+
+		// キャプチャスレッドを起動
+		{
+			m_thread = std::thread{ Run, std::ref(*this) };
+
+			return true;
+		}
+	}
+
+	bool Webcam::WebcamDetail::isActive() const
+	{
+		return m_thread.joinable();
+	}
+
+	uint32 Webcam::WebcamDetail::cameraIndex() const
+	{
+		return m_cameraIndex;
+	}
+
+	Size Webcam::WebcamDetail::getResolution() const
+	{
+		return m_captureResolution;
+	}
+
+	bool Webcam::WebcamDetail::setResolution(const Size& resolution)
+	{
+		if (not m_capture.isOpened())
+		{
+			return false;
+		}
+
+		// start 後は変更できない
+		if (m_thread.joinable())
+		{
+			return false;
+		}
+
+		// すでに同じ解像度が設定されている
+		if (resolution == m_captureResolution)
+		{
+			return true;
+		}
+
+		if ((not m_capture.set(cv::CAP_PROP_FRAME_WIDTH, resolution.x))
+			|| (not m_capture.set(cv::CAP_PROP_FRAME_HEIGHT, resolution.y)))
+		{
+			m_capture.set(cv::CAP_PROP_FRAME_WIDTH, m_captureResolution.x);
+			m_capture.set(cv::CAP_PROP_FRAME_HEIGHT, m_captureResolution.y);
+			return false;
+		}
+		else
+		{
+			m_capture >> m_frame;
+			m_captureResolution.set(m_frame.cols, m_frame.rows);
+			m_image = Image{ m_captureResolution, Color{ 255 } };
+			return (m_captureResolution == resolution);
+		}
+	}
+
+	bool Webcam::WebcamDetail::hasNewFrame()
+	{
+		std::lock_guard lock{ m_imageMutex };
+
+		return (0 < m_newFrameCount);
+	}
+
+	bool Webcam::WebcamDetail::getFrame(Image& image)
+	{
+		if (not isActive())
+		{
+			return false;
+		}
+
+		image.resize(m_captureResolution);
+		{
+			std::lock_guard lock{ m_imageMutex };
+
+			std::memcpy(image.data(), m_image.data(), image.size_bytes());
+
+			m_newFrameCount = 0;
+		}
+
+		return true;
+	}
+
+	bool Webcam::WebcamDetail::getFrame(DynamicTexture& texture)
+	{
+		if (not isActive())
+		{
+			return false;
+		}
+
+		{
+			std::lock_guard lock{ m_imageMutex };
+
+			const bool result = texture.fill(m_image);
+
+			m_newFrameCount = 0;
+
+			return result;
+		}
+	}
+	
+	void Webcam::WebcamDetail::Run(WebcamDetail& webcam)
+	{
+		auto& capture = webcam.m_capture;
+
+		while (not webcam.m_abort)
+		{
+			if (not capture.grab())
+			{
+				System::Sleep(5);
+				continue;
+			}
+
+			if (not capture.retrieve(webcam.m_frame))
+			{
+				continue;
+			}
+
+			{
+				std::lock_guard lock{ webcam.m_imageMutex };
+
+				detail::CopyFrame(webcam.m_frame, webcam.m_image);
+
+				++webcam.m_newFrameCount;
+			}
+		}
+	}
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
@@ -37,6 +37,7 @@ namespace s3d
 
 		m_abort = false;
 
+		// TODO: カメラのデフォルトの解像度も取得したい
 		m_capture.setResolution(m_captureResolution);
 
 		if (not m_capture.open())
@@ -83,11 +84,6 @@ namespace s3d
 
 	bool Webcam::WebcamDetail::start()
 	{
-		if (not m_capture.isOpened())
-		{
-			return false;
-		}
-
 		// すでに start 後の場合は何もしない
 		if (m_thread.joinable())
 		{
@@ -207,7 +203,15 @@ namespace s3d
 
 		if (webcam.m_abort)
 		{
+			// false を返して疑似スレッド終了
 			return false;
+		}
+
+		if (not capture.isOpened())
+		{
+			// isOpen != true でなくても start できる代わりに、
+			// ここで open チェック
+			return true;
 		}
 
 		if (capture.grab())

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
@@ -1,0 +1,74 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include <Siv3D/Webcam.hpp>
+# include <Siv3D/OpenCV_Bridge.hpp>
+
+namespace s3d
+{
+	class Webcam::WebcamDetail
+	{
+	public:
+
+		WebcamDetail();
+
+		~WebcamDetail();
+
+		bool open(uint32 cameraIndex);
+
+		void close();
+
+		bool isOpen();
+
+		bool start();
+
+		bool isActive() const;
+
+		uint32 cameraIndex() const;
+
+		Size getResolution() const;
+
+		bool setResolution(const Size& resolution);
+
+		bool hasNewFrame();
+
+		bool getFrame(Image& image);
+
+		bool getFrame(DynamicTexture& texture);
+
+	private:
+
+		cv::VideoCapture m_capture;
+
+		uint32 m_cameraIndex = 0;
+
+		std::thread m_thread;
+
+		Size m_captureResolution = Size{ 0, 0 };
+
+		cv::Mat_<cv::Vec3b> m_frame;
+
+		std::atomic<bool> m_abort = { false };
+
+		//////
+		//
+		std::mutex m_imageMutex;
+
+		Image m_image;
+
+		int32 m_newFrameCount = 0;
+		//
+		//////
+
+		static void Run(WebcamDetail& webcam);
+	};
+}

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
@@ -11,7 +11,6 @@
 
 # pragma once
 # include <Siv3D/Webcam.hpp>
-# include <Siv3D/Math.hpp>
 # include <Siv3D/PseudoThread/PseudoThread.hpp>
 # include "FrameBufferUnpacker.hpp"
 # include "WebCameraCapture.hpp"

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
@@ -14,151 +14,10 @@
 # include <Siv3D/Math.hpp>
 # include <Siv3D/PseudoThread/PseudoThread.hpp>
 # include "FrameBufferUnpacker.hpp"
+# include "WebCameraCapture.hpp"
 
 namespace s3d
 {
-	namespace detail
-	{
-		using siv3dOpenCameraCallback = void(*)(GLuint elementID, void* userData);
-		using siv3dPlayVideoCallback = void(*)(void* userData);
-
-		__attribute__((import_name("siv3dOpenCamera")))
-		extern void siv3dOpenCamera(int width, int height, siv3dOpenCameraCallback callback, void* callbackArg);
-
-		__attribute__((import_name("siv3dQueryVideoPlaybackedTime")))
-		extern double siv3dQueryVideoPlaybackedTime(GLuint elementID);
-
-		__attribute__((import_name("siv3dCaptureVideoFrame")))
-		extern void siv3dCaptureVideoFrame(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLuint elementID);
-
-		__attribute__((import_name("siv3dPlayVideo")))
-		extern void siv3dPlayVideo(GLuint elementID);
-
-		__attribute__((import_name("siv3dStopVideo")))
-		extern void siv3dStopVideo(GLuint elementID);
-
-		__attribute__((import_name("siv3dDestroyVideo")))
-		extern void siv3dDestroyVideo(GLuint elementID);
-
-		class WebCameraCapture
-		{
-		public:
-
-			WebCameraCapture()
-			{
-				::glGenTextures(1, &m_videoBufferTexture);
-				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
-				{
-					::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-					::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-				}
-				::glBindTexture(GL_TEXTURE_2D, 0);
-
-				::glGenFramebuffers(1, &m_videoBufferFrameBuffer);
-			}
-
-			~WebCameraCapture()
-			{
-				release();
-
-				::glDeleteTextures(1, &m_videoBufferTexture);
-				::glDeleteFramebuffers(1, &m_videoBufferFrameBuffer);
-			}
-
-			bool open()
-			{
-				detail::siv3dOpenCamera(m_captureResolution.x, m_captureResolution.y, &OnOpened, this);
-				return true;
-			}
-
-			void stop()
-			{
-				detail::siv3dStopVideo(m_videoElementID);
-			}
-
-			void release()
-			{
-				detail::siv3dDestroyVideo(m_videoElementID);
-				m_videoElementID = 0;
-			}
-
-			void setResolution(const Size& resolution)
-			{
-				m_captureResolution = resolution;
-			}
-
-			bool grab()
-			{
-				auto currentPlaybackedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
-				return (currentPlaybackedTime - m_lastFrameCapturedTime) > 0.001;
-			}
-		
-			GLuint capture()
-			{
-				m_lastFrameCapturedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
-
-				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
-				{
-					detail::siv3dCaptureVideoFrame(
-						GL_TEXTURE_2D, 0, GL_RGBA8, 
-						m_captureResolution.x, m_captureResolution.y, 
-						0, GL_RGBA, GL_UNSIGNED_BYTE, m_videoElementID);
-				}
-				::glBindTexture(GL_TEXTURE_2D, 0);
-
-				return m_videoBufferFrameBuffer;
-			}
-
-			bool isOpened() const
-			{
-				return m_videoElementID != 0;
-			}
-
-		private:
-
-			static void OnOpened(GLuint elementID, void* userData)
-			{
-				auto& webcam = *static_cast<WebCameraCapture*>(userData);
-
-				webcam.m_videoElementID = elementID;
-				webcam.prepareBuffers();
-
-				detail::siv3dPlayVideo(elementID);
-			} 
-
-			void prepareBuffers()
-			{
-				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
-				{
-					::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, m_captureResolution.x, m_captureResolution.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-				}
-				::glBindTexture(GL_TEXTURE_2D, 0);
-
-				::glBindFramebuffer(GL_FRAMEBUFFER, m_videoBufferFrameBuffer);
-				{
-					::glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_videoBufferTexture, 0);
-
-					if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) 
-					{
-						LOG_ERROR(U"Incomplete Framebuffer");
-						return;
-					}
-				}
-				::glBindFramebuffer(GL_FRAMEBUFFER, 0);
-			}
-
-			Size m_captureResolution = { 0, 0 };
-
-			GLuint m_videoElementID = 0;
-
-			GLuint m_videoBufferTexture = 0;
-
-			GLuint m_videoBufferFrameBuffer = 0;
-
-			double m_lastFrameCapturedTime = 0.0;
-		};
-	}
-
 	class Webcam::WebcamDetail
 	{
 	public:
@@ -191,7 +50,7 @@ namespace s3d
 
 	private:
 
-		detail::WebCameraCapture m_capture;
+		WebCameraCapture m_capture;
 
 		uint32 m_cameraIndex = 0;
 

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.hpp
@@ -11,10 +11,154 @@
 
 # pragma once
 # include <Siv3D/Webcam.hpp>
-# include <Siv3D/OpenCV_Bridge.hpp>
+# include <Siv3D/Math.hpp>
+# include <Siv3D/PseudoThread/PseudoThread.hpp>
+# include "FrameBufferUnpacker.hpp"
 
 namespace s3d
 {
+	namespace detail
+	{
+		using siv3dOpenCameraCallback = void(*)(GLuint elementID, void* userData);
+		using siv3dPlayVideoCallback = void(*)(void* userData);
+
+		__attribute__((import_name("siv3dOpenCamera")))
+		extern void siv3dOpenCamera(int width, int height, siv3dOpenCameraCallback callback, void* callbackArg);
+
+		__attribute__((import_name("siv3dQueryVideoPlaybackedTime")))
+		extern double siv3dQueryVideoPlaybackedTime(GLuint elementID);
+
+		__attribute__((import_name("siv3dCaptureVideoFrame")))
+		extern void siv3dCaptureVideoFrame(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLuint elementID);
+
+		__attribute__((import_name("siv3dPlayVideo")))
+		extern void siv3dPlayVideo(GLuint elementID);
+
+		__attribute__((import_name("siv3dStopVideo")))
+		extern void siv3dStopVideo(GLuint elementID);
+
+		__attribute__((import_name("siv3dDestroyVideo")))
+		extern void siv3dDestroyVideo(GLuint elementID);
+
+		class WebCameraCapture
+		{
+		public:
+
+			WebCameraCapture()
+			{
+				::glGenTextures(1, &m_videoBufferTexture);
+				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+				{
+					::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+					::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+				}
+				::glBindTexture(GL_TEXTURE_2D, 0);
+
+				::glGenFramebuffers(1, &m_videoBufferFrameBuffer);
+			}
+
+			~WebCameraCapture()
+			{
+				release();
+
+				::glDeleteTextures(1, &m_videoBufferTexture);
+				::glDeleteFramebuffers(1, &m_videoBufferFrameBuffer);
+			}
+
+			bool open()
+			{
+				detail::siv3dOpenCamera(m_captureResolution.x, m_captureResolution.y, &OnOpened, this);
+				return true;
+			}
+
+			void stop()
+			{
+				detail::siv3dStopVideo(m_videoElementID);
+			}
+
+			void release()
+			{
+				detail::siv3dDestroyVideo(m_videoElementID);
+				m_videoElementID = 0;
+			}
+
+			void setResolution(const Size& resolution)
+			{
+				m_captureResolution = resolution;
+			}
+
+			bool grab()
+			{
+				auto currentPlaybackedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
+				return (currentPlaybackedTime - m_lastFrameCapturedTime) > 0.001;
+			}
+		
+			GLuint capture()
+			{
+				m_lastFrameCapturedTime = detail::siv3dQueryVideoPlaybackedTime(m_videoElementID);
+
+				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+				{
+					detail::siv3dCaptureVideoFrame(
+						GL_TEXTURE_2D, 0, GL_RGBA8, 
+						m_captureResolution.x, m_captureResolution.y, 
+						0, GL_RGBA, GL_UNSIGNED_BYTE, m_videoElementID);
+				}
+				::glBindTexture(GL_TEXTURE_2D, 0);
+
+				return m_videoBufferFrameBuffer;
+			}
+
+			bool isOpened() const
+			{
+				return m_videoElementID != 0;
+			}
+
+		private:
+
+			static void OnOpened(GLuint elementID, void* userData)
+			{
+				auto& webcam = *static_cast<WebCameraCapture*>(userData);
+
+				webcam.m_videoElementID = elementID;
+				webcam.prepareBuffers();
+
+				detail::siv3dPlayVideo(elementID);
+			} 
+
+			void prepareBuffers()
+			{
+				::glBindTexture(GL_TEXTURE_2D, m_videoBufferTexture);
+				{
+					::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, m_captureResolution.x, m_captureResolution.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+				}
+				::glBindTexture(GL_TEXTURE_2D, 0);
+
+				::glBindFramebuffer(GL_FRAMEBUFFER, m_videoBufferFrameBuffer);
+				{
+					::glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_videoBufferTexture, 0);
+
+					if (::glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) 
+					{
+						LOG_ERROR(U"Incomplete Framebuffer");
+						return;
+					}
+				}
+				::glBindFramebuffer(GL_FRAMEBUFFER, 0);
+			}
+
+			Size m_captureResolution = { 0, 0 };
+
+			GLuint m_videoElementID = 0;
+
+			GLuint m_videoBufferTexture = 0;
+
+			GLuint m_videoBufferFrameBuffer = 0;
+
+			double m_lastFrameCapturedTime = 0.0;
+		};
+	}
+
 	class Webcam::WebcamDetail
 	{
 	public:
@@ -47,28 +191,30 @@ namespace s3d
 
 	private:
 
-		cv::VideoCapture m_capture;
+		detail::WebCameraCapture m_capture;
 
 		uint32 m_cameraIndex = 0;
 
-		std::thread m_thread;
+		PseudoThread m_thread;
 
-		Size m_captureResolution = Size{ 0, 0 };
+		Size m_captureResolution = Size { 640, 480 };
 
-		cv::Mat_<cv::Vec3b> m_frame;
+		GLuint m_copyFrameBuffer = 0;
+
+		Array<FrameBufferUnpacker> m_frameBufferUnpackers;		
 
 		std::atomic<bool> m_abort = { false };
 
 		//////
 		//
-		std::mutex m_imageMutex;
-
-		Image m_image;
+		GLuint m_capturedFrameBuffer = 0;
 
 		int32 m_newFrameCount = 0;
+
+		int32 m_totalFrameCount = 0;
 		//
 		//////
 
-		static void Run(WebcamDetail& webcam);
+		static bool Run(WebcamDetail& webcam);
 	};
 }

--- a/Siv3D/src/Siv3D/SimpleGUI/SivSimpleGUI.cpp
+++ b/Siv3D/src/Siv3D/SimpleGUI/SivSimpleGUI.cpp
@@ -889,10 +889,18 @@ namespace s3d
 					text.cursorStopwatch.restart();
 					text.leftPressStopwatch.reset();
 					text.rightPressStopwatch.reset();
+
+				# if SIV3D_PLATFORM(WEB)
+					Platform::Web::TextInput::RequestEnableIME();		
+				# endif
 				}
 				else
 				{
 					text.active = false;
+
+				# if SIV3D_PLATFORM(WEB)
+					Platform::Web::TextInput::RequestDisableIME();		
+				# endif
 				}
 			}
 
@@ -936,6 +944,10 @@ namespace s3d
 				if (const String raw = TextInput::GetRawInput(); raw.includes(U'\r') || raw.includes(U'\t'))
 				{
 					text.active = false;
+
+				# if SIV3D_PLATFORM(WEB)					
+					Platform::Web::TextInput::RequestDisableIME();					
+				# endif
 				}
 
 				if ((0 < text.cursorPos) && (KeyLeft.down() || (KeyLeft.pressedDuration() > SecondsF(0.33) && text.leftPressStopwatch > SecondsF(0.06))))

--- a/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
+++ b/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
@@ -177,6 +177,21 @@ namespace s3d
 			}
 		}
 	}
+	
+# elif SIV3D_PLATFORM(WEB)
+
+	namespace Platform::Web::TextInput
+	{
+		void RequestEnableIME() 
+		{
+			Siv3DEngine::Get<ISiv3DTextInput>()->enableIME(true);
+		}
+
+		void RequestDisableIME() 
+		{
+			Siv3DEngine::Get<ISiv3DTextInput>()->enableIME(false);
+		}
+	}
 
 # endif
 }

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -28,5 +28,9 @@ Module.preRun = [
       addEventListener() {},
       removeEventListener() {}
     }
+
+    class FileReader {
+      constructor() {}
+    }
   }
 ]

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -23,17 +23,19 @@ Module.preRun = [
       createElement() { 
         return { 
           style: {},
-          parentNode: {
-            prepend() {}
-          }
+          addEventListener() {},
+          removeEventListener() {},
         };
-      }
+      }, 
     }
     
     Module.canvas = {
       style: {},
+      parentNode: {
+        prepend() {}
+      },
       addEventListener() {},
-      removeEventListener() {}
+      removeEventListener() {},
     }
 
     global.FileReader = class {

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -20,7 +20,11 @@ Module.preRun = [
     }
 
     global.document = {
-      createElement() { return {}; }
+      createElement() { 
+        return { 
+          style: {} 
+        };
+      }
     }
     
     Module.canvas = {

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -29,7 +29,7 @@ Module.preRun = [
       removeEventListener() {}
     }
 
-    class FileReader {
+    global.FileReader = class {
       constructor() {}
     }
   }

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -11,13 +11,18 @@ Module.preRun = [
     // Mock Implementations 
     //
     global.navigator = {
-      getGamepads: function() {
-        return [];
-      }
+      getGamepads() { return []; }
+    }
+
+    global.window = {
+      addEventListener() {},
+      removeEventListener() {}
     }
     
     Module.canvas = {
-      style: {}
+      style: {},
+      addEventListener() {},
+      removeEventListener() {}
     }
   }
 ]

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -22,7 +22,10 @@ Module.preRun = [
     global.document = {
       createElement() { 
         return { 
-          style: {} 
+          style: {},
+          parentNode: {
+            prepend() {}
+          }
         };
       }
     }

--- a/Test/Siv3DTest.js
+++ b/Test/Siv3DTest.js
@@ -18,6 +18,10 @@ Module.preRun = [
       addEventListener() {},
       removeEventListener() {}
     }
+
+    global.document = {
+      createElement() { return {}; }
+    }
     
     Module.canvas = {
       style: {},

--- a/Web/CMakeLists.txt
+++ b/Web/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/TextInput/CTextInput.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Time/SivTime.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/ToastNotification/CToastNotification.cpp
+  ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
+  ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/WebcamInfo/SivWebcamInfo.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/CWindow.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/WindowFactory.cpp
@@ -425,8 +427,8 @@ add_library(
   ../Siv3D/src/Siv3D/VideoTexture/SivVideoTexture.cpp
   ../Siv3D/src/Siv3D/VideoTexture/VideoTextureDetail.cpp
   ../Siv3D/src/Siv3D/Wave/SivWave.cpp
-  ../Siv3D/src/Siv3D/Webcam/SivWebcam.cpp
-  ../Siv3D/src/Siv3D/Webcam/WebcamDetail.cpp
+  # ../Siv3D/src/Siv3D/Webcam/SivWebcam.cpp
+  # ../Siv3D/src/Siv3D/Webcam/WebcamDetail.cpp
   ../Siv3D/src/Siv3D/Window/SivWindow.cpp
   ../Siv3D/src/Siv3D/Window/Null/CWindow_Null.cpp
   ../Siv3D/src/Siv3D/XInput/Null/CXInput_Null.cpp

--- a/Web/CMakeLists.txt
+++ b/Web/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/ToastNotification/CToastNotification.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/SivWebcam.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebcamDetail.cpp
+  ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Webcam/WebCameraCapture.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/WebcamInfo/SivWebcamInfo.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/CWindow.cpp
   ../Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/WindowFactory.cpp

--- a/Web/CMakeLists.txt
+++ b/Web/CMakeLists.txt
@@ -377,7 +377,7 @@ add_library(
   ../Siv3D/src/Siv3D/SoundFont/SoundFontFactory.cpp
   ../Siv3D/src/Siv3D/Spline2D/SivSpline2D.cpp
   ../Siv3D/src/Siv3D/String/SivString.cpp
-  # ../Siv3D/src/Siv3D/String/Levenshtein.cpp
+  ../Siv3D/src/Siv3D/String/Levenshtein.cpp
   ../Siv3D/src/Siv3D/StringView/SivStringView.cpp
   ../Siv3D/src/Siv3D/Subdivision2D/SivSubdivision2D.cpp
   ../Siv3D/src/Siv3D/SVG/SivSVG.cpp

--- a/Web/Siv3D.js
+++ b/Web/Siv3D.js
@@ -1,4 +1,18 @@
 mergeInto(LibraryManager.library, {
+    //
+    // GamePads
+    //
+    siv3dGetJoystickInfo: function(joystickId) {
+        return GLFW.joys[joystickId].id;
+    },
+    siv3dGetJoystickInfo__sig: "iiiii",
+
+    glfwGetJoystickHats: function () {
+        // Not supported.
+        return 0;
+    },
+    glfwGetJoystickHats__sig: "iii",
+
     glfwGetKeysSiv3D: function (windowid) {
         const window = GLFW.WindowFromId(windowid);
         if (!window) return 0;
@@ -10,6 +24,9 @@ mergeInto(LibraryManager.library, {
     },
     glfwGetKeysSiv3D__sig: "ii",
 
+    //
+    // Monitors
+    //
     glfwGetMonitorInfo_Siv3D: function(handle, displayID, xpos, ypos, w, h) {
         setValue(displayID, 1, 'i32');
         setValue(xpos, 0, 'i32');
@@ -90,7 +107,7 @@ mergeInto(LibraryManager.library, {
     },
     siv3dRegisterDragExit__sig: "vi",
 
-    $s3dDragDropFileReader: null,
+    $siv3dDragDropFileReader: null,
     siv3dRegisterDragDrop: function(ptr) {
         Module["canvas"].ondrop = function (e) {
             e.preventDefault();
@@ -110,25 +127,25 @@ mergeInto(LibraryManager.library, {
             } else if (items[0].kind === 'file') {
                 const file = items[0].getAsFile();
 
-                if (!s3dDragDropFileReader) {
-                    s3dDragDropFileReader = new FileReader();
+                if (!siv3dDragDropFileReader) {
+                    siv3dDragDropFileReader = new FileReader();
                 }
 
                 const filePath = `/tmp/${file.name}`;
 
-                s3dDragDropFileReader.addEventListener("load", function onLoaded() {
-                    FS.writeFile(filePath, new Uint8Array(s3dDragDropFileReader.result));
+                siv3dDragDropFileReader.addEventListener("load", function onLoaded() {
+                    FS.writeFile(filePath, new Uint8Array(siv3dDragDropFileReader.result));
 
                     const namePtr = allocate(intArrayFromString(filePath), ALLOC_NORMAL);
                     {{{ makeDynCall('vi', 'ptr') }}}(namePtr);
 
-                    s3dDragDropFileReader.removeEventListener("load", onLoaded);
+                    siv3dDragDropFileReader.removeEventListener("load", onLoaded);
                 });
 
-                s3dDragDropFileReader.readAsArrayBuffer(file);              
+                siv3dDragDropFileReader.readAsArrayBuffer(file);              
             }
         };
     },
     siv3dRegisterDragDrop__sig: "vi",
-    siv3dRegisterDragDrop__deps: [ "$s3dDragDropFileReader", "$FS" ],
+    siv3dRegisterDragDrop__deps: [ "$siv3dDragDropFileReader", "$FS" ],
 })

--- a/Web/Siv3D.js
+++ b/Web/Siv3D.js
@@ -369,6 +369,36 @@ mergeInto(LibraryManager.library, {
     siv3dSaveDialog__deps: [ "$siv3dSaveFileBufferWritePos", "$siv3dDefaultSaveFileName" ],
 
     //
+    // Clipboard
+    //
+    siv3dSetClipboardText: function(ctext) {
+        const text = UTF8ToString(ctext);
+        
+        siv3dRegisterUserAction(function () {
+            navigator.clipboard.writeText(text);
+        });
+    },
+    siv3dSetClipboardText__sig: "vi",
+    siv3dSetClipboardText__deps: [ "$siv3dRegisterUserAction" ],
+
+    siv3dGetClipboardText: function(callback, promise) {
+        siv3dRegisterUserAction(function () {
+            navigator.clipboard.readText()
+            .then(str => {
+                const strPtr = allocate(intArrayFromString(str), 'i8', ALLOC_NORMAL);       
+                {{{ makeDynCall('vii', 'callback') }}}(strPtr, promise);
+                Module["_free"](strPtr);
+            })
+            .catch(e => {
+                {{{ makeDynCall('vii', 'callback') }}}(0, promise);
+            })
+        });
+        
+    },
+    siv3dGetClipboardText__sig: "vii",
+    siv3dGetClipboardText__deps: [ "$siv3dRegisterUserAction" ],
+
+    //
     // TextInput
     //
     $siv3dTextInputElement: null,

--- a/Web/Siv3D.js
+++ b/Web/Siv3D.js
@@ -227,4 +227,49 @@ mergeInto(LibraryManager.library, {
     },
     siv3dDestroyVideo__sig: "vi",
     siv3dDestroyVideo__deps: ["$videoElements"],
+
+    //
+    // User Action Emulation
+    //
+    $siv3dHasUserActionTriggered: false,
+    $siv3dPendingUserActions: [],
+
+    $siv3dTriggerUserAction: function() {
+        for (let action of siv3dPendingUserActions) {
+            action();
+        }
+
+        siv3dPendingUserActions.splice(0);
+        siv3dHasUserActionTriggered = false;
+    },
+    $siv3dTriggerUserAction__deps: [ "$siv3dPendingUserActions" ],
+
+    $siv3dRegisterUserAction: function(func) {
+        siv3dPendingUserActions.push(func);
+    },
+    $siv3dRegisterUserAction__deps: [ "$siv3dPendingUserActions" ],
+
+    $siv3dUserActionHookCallBack: function() {
+        if (!siv3dHasUserActionTriggered) {
+            setTimeout(siv3dTriggerUserAction, 30);
+            siv3dHasUserActionTriggered = true;
+        }
+    },
+    $siv3dUserActionHookCallBack__deps: [ "$siv3dHasUserActionTriggered", "$siv3dTriggerUserAction" ],
+
+    siv3dStartUserActionHook: function() {
+        Module["canvas"].addEventListener('touchstart', siv3dUserActionHookCallBack);
+        Module["canvas"].addEventListener('mousedown', siv3dUserActionHookCallBack);
+        window.addEventListener('keydown', siv3dUserActionHookCallBack);
+    },
+    siv3dStartUserActionHook__sig: "v",
+    siv3dStartUserActionHook__deps: [ "$siv3dUserActionHookCallBack", "$siv3dHasUserActionTriggered" ],
+
+    siv3dStopUserActionHook: function() {
+        Module["canvas"].removeEventListener('touchstart', siv3dUserActionHookCallBack);
+        Module["canvas"].removeEventListener('mousedown', siv3dUserActionHookCallBack);
+        window.removeEventListener('keydown', siv3dUserActionHookCallBack);
+    },
+    siv3dStopUserActionHook__sig: "v",
+    siv3dStopUserActionHook__deps: [ "$siv3dUserActionHookCallBack" ],
 })


### PR DESCRIPTION
v0.4.3 からの機能移植が中心です

- Dialog
  - OpenDialog は Web 固有版を使用する必要がある
  - SaveDialog はユーザのファイル名指定を読み取ることはできない
- TextInput
  - InputElement によるエミュレーション
  - 文字列のコピーが 1 回目だけ失敗する
- Clipboard
  - ReadText: Web 固有版を使用する必要がある
  - テキスト以外は未対応、また FireFox もみ対応