### PR TITLE
[Linux] TextInputのIME対応

### DIFF
--- a/Siv3D/include/Siv3D.hpp
+++ b/Siv3D/include/Siv3D.hpp
@@ -1566,7 +1566,7 @@
 // テキスト入力 | Text input
 # include <Siv3D/TextInput.hpp>
 
-// 下線のスタイル
+// 下線のスタイル | Underline style
 # include <Siv3D/UnderlineStyle.hpp>
 
 //////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D.hpp
+++ b/Siv3D/include/Siv3D.hpp
@@ -1566,8 +1566,8 @@
 // テキスト入力 | Text input
 # include <Siv3D/TextInput.hpp>
 
-// 編集中テキストの文字スタイル
-# include <Siv3D/EditingTextCharStyle.hpp>
+// 下線のスタイル
+# include <Siv3D/UnderlineStyle.hpp>
 
 //////////////////////////////////////////////////
 //

--- a/Siv3D/include/Siv3D.hpp
+++ b/Siv3D/include/Siv3D.hpp
@@ -1566,6 +1566,9 @@
 // テキスト入力 | Text input
 # include <Siv3D/TextInput.hpp>
 
+// 編集中テキストの文字スタイル
+# include <Siv3D/EditingTextCharStyle.hpp>
+
 //////////////////////////////////////////////////
 //
 //	エフェクト | Effect

--- a/Siv3D/include/Siv3D/EditingTextCharStyle.hpp
+++ b/Siv3D/include/Siv3D/EditingTextCharStyle.hpp
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2021 Ryo Suzuki
+//	Copyright (c) 2016-2021 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include "Common.hpp"
+# include <ThirdParty/EnumBitmask/EnumBitmask.hpp>
+
+namespace s3d
+{
+	/// @brief 編集中テキストの文字スタイル
+	enum class EditingTextCharStyle
+	{
+		/// @brief スタイルなし
+		NoStyle = 0,
+		/// @brief 下線,実線(_________________)
+		Underline = 1 << 0,
+		/// @brief 下線,破線(_ _ _ _ _ _ _ _ _)
+		DashedUnderline = 1 << 1,
+		/// @brief 下線のマスク
+		UnderlineMask = 0b11, 
+		/// @brief 反転(█████████████████)
+		Highlight = 1 << 2
+	};
+	DEFINE_BITMASK_OPERATORS(EditingTextCharStyle)
+}

--- a/Siv3D/include/Siv3D/TextInput.hpp
+++ b/Siv3D/include/Siv3D/TextInput.hpp
@@ -14,6 +14,7 @@
 # include "String.hpp"
 # include "Array.hpp"
 # include "Font.hpp"
+# include "EditingTextCharStyle.hpp"
 # include "TextInputMode.hpp"
 
 namespace s3d
@@ -50,6 +51,20 @@ namespace s3d
 			const ColorF& selectedBackgroundColor = ColorF{ 0.55, 0.85, 1.0 },
 			const ColorF& frameColor = ColorF{ 0.75 },
 			const ColorF& textColor = ColorF{ 0.0 });
+	}
+
+# elif SIV3D_PLATFORM(LINUX)
+
+	namespace Platform::Linux::TextInput
+	{
+		void EnableIME();
+
+		void DisableIME();
+
+		[[nodiscard]]
+		int32 GetCursorIndex();
+
+		const Array<EditingTextCharStyle>& GetEditingTextStyle();
 	}
 
 # elif SIV3D_PLATFORM(WEB)

--- a/Siv3D/include/Siv3D/TextInput.hpp
+++ b/Siv3D/include/Siv3D/TextInput.hpp
@@ -14,7 +14,7 @@
 # include "String.hpp"
 # include "Array.hpp"
 # include "Font.hpp"
-# include "EditingTextCharStyle.hpp"
+# include "UnderlineStyle.hpp"
 # include "TextInputMode.hpp"
 
 namespace s3d
@@ -64,7 +64,7 @@ namespace s3d
 		[[nodiscard]]
 		int32 GetCursorIndex();
 
-		const Array<EditingTextCharStyle>& GetEditingTextStyle();
+		const Array<UnderlineStyle>& GetEditingTextStyle();
 	}
 
 # elif SIV3D_PLATFORM(WEB)

--- a/Siv3D/include/Siv3D/TextInput.hpp
+++ b/Siv3D/include/Siv3D/TextInput.hpp
@@ -64,6 +64,7 @@ namespace s3d
 		[[nodiscard]]
 		int32 GetCursorIndex();
 
+		[[nodiscard]]
 		const Array<UnderlineStyle>& GetEditingTextStyle();
 	}
 

--- a/Siv3D/include/Siv3D/UnderlineStyle.hpp
+++ b/Siv3D/include/Siv3D/UnderlineStyle.hpp
@@ -16,7 +16,7 @@
 namespace s3d
 {
 	/// @brief 下線のスタイル
-	enum class UnderlineStyle
+	enum class UnderlineStyle : uint8
 	{
 		/// @brief スタイルなし
 		NoStyle = 0,

--- a/Siv3D/include/Siv3D/UnderlineStyle.hpp
+++ b/Siv3D/include/Siv3D/UnderlineStyle.hpp
@@ -15,19 +15,19 @@
 
 namespace s3d
 {
-	/// @brief 編集中テキストの文字スタイル
-	enum class EditingTextCharStyle
+	/// @brief 下線のスタイル
+	enum class UnderlineStyle
 	{
 		/// @brief スタイルなし
 		NoStyle = 0,
-		/// @brief 下線,実線(_________________)
+		/// @brief 実線(_________________)
 		Underline = 1 << 0,
-		/// @brief 下線,破線(_ _ _ _ _ _ _ _ _)
+		/// @brief 破線(_ _ _ _ _ _ _ _ _)
 		DashedUnderline = 1 << 1,
 		/// @brief 下線のマスク
 		UnderlineMask = 0b11, 
 		/// @brief 反転(█████████████████)
 		Highlight = 1 << 2
 	};
-	DEFINE_BITMASK_OPERATORS(EditingTextCharStyle)
+	DEFINE_BITMASK_OPERATORS(UnderlineStyle)
 }

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
@@ -110,7 +110,7 @@ namespace s3d
 	void CTextInput::update()
 	{
 		{
-			std::lock_guard lock{ m_mutex };
+			std::lock_guard lock{ m_mutexChars };
 			
 			m_chars = m_internalChars;
 			
@@ -130,7 +130,7 @@ namespace s3d
 	
 	void CTextInput::pushChar(const uint32 ch)
 	{
-		std::lock_guard lock{ m_mutex };
+		std::lock_guard lock{ m_mutexChars };
 		
 		m_internalChars.push_back(static_cast<char32>(ch));
 	}

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
@@ -162,7 +162,7 @@ namespace s3d
 		return dummy;
 	}
 
-	const Array<EditingTextCharStyle>& CTextInput::getEditingTextStyle() const
+	const Array<UnderlineStyle>& CTextInput::getEditingTextStyle() const
 	{
 		return m_preeditTextStyle;
 	}
@@ -189,10 +189,10 @@ namespace s3d
 			m_internalPreeditText.insert(call_data->chg_first, text);
 
 			m_internalPreeditTextStyle.erase(std::next(m_internalPreeditTextStyle.begin(), call_data->chg_first), std::next(m_internalPreeditTextStyle.begin(), call_data->chg_first + call_data->chg_length));
-			m_internalPreeditTextStyle.insert(std::next(m_internalPreeditTextStyle.begin(), call_data->chg_first), text.length(), EditingTextCharStyle::NoStyle);
+			m_internalPreeditTextStyle.insert(std::next(m_internalPreeditTextStyle.begin(), call_data->chg_first), text.length(), UnderlineStyle::NoStyle);
 
 			auto itr = std::next(m_internalPreeditTextStyle.begin(), call_data->chg_first);
-			EditingTextCharStyle style = EditingTextCharStyle::NoStyle;
+			UnderlineStyle style = UnderlineStyle::NoStyle;
 			for(size_t idx = 0; idx < text.length(); idx++)
 			{
 				auto feedback = call_data->text->feedback[idx];
@@ -204,15 +204,15 @@ namespace s3d
 				{
 					if (feedback & XIMReverse)
 					{
-						*itr |= EditingTextCharStyle::Highlight;
+						*itr |= UnderlineStyle::Highlight;
 					}
 					if (feedback & XIMHighlight)
 					{
-						*itr |= EditingTextCharStyle::DashedUnderline;
+						*itr |= UnderlineStyle::DashedUnderline;
 					}
 					if (feedback & XIMUnderline)
 					{
-						*itr = (*itr & ~EditingTextCharStyle::UnderlineMask) | EditingTextCharStyle::Underline;
+						*itr = (*itr & ~UnderlineStyle::UnderlineMask) | UnderlineStyle::Underline;
 					}
 				}
 				itr++;

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp
@@ -26,22 +26,22 @@ extern "C"
 	XIMCallback preeditDone;
 	XIMCallback preeditCaret;
 
-	void preeditStartCallback(XIC, XPointer, XPointer)
+	static void preeditStartCallback(XIC, XPointer, XPointer)
 	{
 		// do nothing
 	}
 
-	void preeditDoneCallback(XIC, XPointer, XPointer)
+	static void preeditDoneCallback(XIC, XPointer, XPointer)
 	{
 		// do nothing
 	}
 
-	void preeditDrawCallback(XIC ic, XPointer client_data, XIMPreeditDrawCallbackStruct *call_data)
+	static void preeditDrawCallback(XIC ic, XPointer client_data, XIMPreeditDrawCallbackStruct *call_data)
 	{
 		pTextInput->preeditDrawCallback(ic, client_data, call_data);
 	}
 
-	void preeditCaretCallback(XIC, XPointer, XIMPreeditCaretCallbackStruct *)
+	static void preeditCaretCallback(XIC, XPointer, XIMPreeditCaretCallbackStruct *)
 	{
 		// do nothing
 	}
@@ -145,7 +145,7 @@ namespace s3d
 		return m_preeditText;
 	}
 	
-	void CTextInput::enableIME(bool enabled)
+	void CTextInput::enableIME(const bool enabled)
 	{
 		m_imeEnabled = enabled;
 		updateICFocus();
@@ -153,7 +153,7 @@ namespace s3d
 	
 	std::pair<int32, int32> CTextInput::getCursorIndex() const
 	{
-		return{ m_preeditCaret, 0};
+		return{ m_preeditCaret, 0 };
 	}
 	
 	const Array<String>& CTextInput::getCandidates() const

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
@@ -40,36 +40,48 @@ namespace s3d
 		std::pair<int32, int32> getCursorIndex() const override;
 		
 		const Array<String>& getCandidates() const override;
+
+		const Array<EditingTextCharStyle>& getEditingTextStyle() const override;
 		
 		//
 		//	Linux
 		//
 		
-		void onHaveMarkedText(const char* text);
+		void preeditDrawCallback(XIC ic, XPointer client_data, XIMPreeditDrawCallbackStruct* call_data);
+
+		void updateWindowFocus(bool focus);
+
+		void sendInputText(const String& text);
 		
 	private:
 
-		std::mutex m_mutex;
+		std::mutex m_mutexChars;
 		
 		String m_internalChars;
 		
 		String m_chars;
 		
 		
-		std::mutex m_mutexMarkedText;
+		std::mutex m_mutexPreeditStatus;
 		
-		String m_internalMarkedText;
+		Array<EditingTextCharStyle> m_internalPreeditTextStyle = {};
+
+		String m_internalPreeditText = U"";
 		
-		String m_markedText;
+		int32 m_internalPreeditCaret = 0;
 		
-		bool m_haveMarkedText = false;
+		Array<EditingTextCharStyle> m_preeditTextStyle = {};
+
+		String m_preeditText = U"";
+
+		int32 m_preeditCaret = 0;
 		
+
+		bool m_imeEnabled = true;
 		
-		Stopwatch m_enterPress;
+		bool m_windowHasFocus = true;
 		
-		Stopwatch m_tabPress;
-		
-		Stopwatch m_backSpacePress;
+		void updateICFocus();
 		
 		static void OnCharacterInput(GLFWwindow*, uint32 codePoint);
 	};

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
@@ -64,15 +64,15 @@ namespace s3d
 		
 		std::mutex m_mutexPreeditStatus;
 		
-		Array<UnderlineStyle> m_internalPreeditTextStyle = {};
+		Array<UnderlineStyle> m_internalPreeditTextStyle;
 
-		String m_internalPreeditText = U"";
+		String m_internalPreeditText;
 		
 		int32 m_internalPreeditCaret = 0;
 		
-		Array<UnderlineStyle> m_preeditTextStyle = {};
+		Array<UnderlineStyle> m_preeditTextStyle;
 
-		String m_preeditText = U"";
+		String m_preeditText;
 
 		int32 m_preeditCaret = 0;
 		

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.hpp
@@ -41,7 +41,7 @@ namespace s3d
 		
 		const Array<String>& getCandidates() const override;
 
-		const Array<EditingTextCharStyle>& getEditingTextStyle() const override;
+		const Array<UnderlineStyle>& getEditingTextStyle() const override;
 		
 		//
 		//	Linux
@@ -64,13 +64,13 @@ namespace s3d
 		
 		std::mutex m_mutexPreeditStatus;
 		
-		Array<EditingTextCharStyle> m_internalPreeditTextStyle = {};
+		Array<UnderlineStyle> m_internalPreeditTextStyle = {};
 
 		String m_internalPreeditText = U"";
 		
 		int32 m_internalPreeditCaret = 0;
 		
-		Array<EditingTextCharStyle> m_preeditTextStyle = {};
+		Array<UnderlineStyle> m_preeditTextStyle = {};
 
 		String m_preeditText = U"";
 

--- a/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
+++ b/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
@@ -39,6 +39,6 @@ namespace s3d
 
 		virtual std::pair<int32, int32> getCursorIndex() const = 0;
 
-		virtual const Array<UnderlineStyle>& getEditingTextStyle() const = 0;
+		virtual const Array<UnderlineStyle>& getEditingTextStyle() const { static const Array<UnderlineStyle> _empty; return _empty; }
 	};
 }

--- a/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
+++ b/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
@@ -38,5 +38,7 @@ namespace s3d
 		virtual const Array<String>& getCandidates() const = 0;
 
 		virtual std::pair<int32, int32> getCursorIndex() const = 0;
+
+		virtual const Array<EditingTextCharStyle>& getEditingTextStyle() const = 0;
 	};
 }

--- a/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
+++ b/Siv3D/src/Siv3D/TextInput/ITextInput.hpp
@@ -39,6 +39,6 @@ namespace s3d
 
 		virtual std::pair<int32, int32> getCursorIndex() const = 0;
 
-		virtual const Array<EditingTextCharStyle>& getEditingTextStyle() const = 0;
+		virtual const Array<UnderlineStyle>& getEditingTextStyle() const = 0;
 	};
 }

--- a/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
+++ b/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
@@ -13,7 +13,7 @@
 # include <Siv3D/Scene.hpp>
 # include <Siv3D/Indexed.hpp>
 # include <Siv3D/DrawableText.hpp>
-# include <Siv3D/EditingTextCharStyle.hpp>
+# include <Siv3D/UnderlineStyle.hpp>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 # include <Siv3D/TextInput/ITextInput.hpp>
 
@@ -198,7 +198,7 @@ namespace s3d
 			return SIV3D_ENGINE(TextInput)->getCursorIndex().first;
 		}
 
-		const Array<EditingTextCharStyle>& GetEditingTextStyle() 
+		const Array<UnderlineStyle>& GetEditingTextStyle() 
 		{
 			return SIV3D_ENGINE(TextInput)->getEditingTextStyle();
 		}

--- a/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
+++ b/Siv3D/src/Siv3D/TextInput/SivTextInput.cpp
@@ -13,6 +13,7 @@
 # include <Siv3D/Scene.hpp>
 # include <Siv3D/Indexed.hpp>
 # include <Siv3D/DrawableText.hpp>
+# include <Siv3D/EditingTextCharStyle.hpp>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 # include <Siv3D/TextInput/ITextInput.hpp>
 
@@ -178,6 +179,31 @@ namespace s3d
 		}
 	}
 	
+# elif SIV3D_PLATFORM(LINUX)
+
+	namespace Platform::Linux::TextInput
+	{
+		void EnableIME()
+		{
+			SIV3D_ENGINE(TextInput)->enableIME(true);
+		}
+
+		void DisableIME()
+		{
+			SIV3D_ENGINE(TextInput)->enableIME(false);
+		}
+
+		int32 GetCursorIndex()
+		{
+			return SIV3D_ENGINE(TextInput)->getCursorIndex().first;
+		}
+
+		const Array<EditingTextCharStyle>& GetEditingTextStyle() 
+		{
+			return SIV3D_ENGINE(TextInput)->getEditingTextStyle();
+		}
+	}
+
 # elif SIV3D_PLATFORM(WEB)
 
 	namespace Platform::Web::TextInput

--- a/Siv3D/src/ThirdParty/GLFW/x11_window.c
+++ b/Siv3D/src/ThirdParty/GLFW/x11_window.c
@@ -1336,11 +1336,19 @@ static void processEvent(XEvent *event)
 
                     if (status == XLookupChars || status == XLookupBoth)
                     {
+                        //-----------------------------------------------
+                        //
+                        //  [Siv3D]
+                        //
+
                         // const char* c = chars;
                         chars[count] = '\0';
                         s3d_InputText(chars);
                         // while (c - chars < count)
                         //     _glfwInputChar(window, decodeUTF8(&c), mods, plain);
+
+                        //
+                        //-----------------------------------------------
                     }
 
                     if (chars != buffer)
@@ -1815,6 +1823,11 @@ static void processEvent(XEvent *event)
             return;
         }
 
+        //-----------------------------------------------
+        //
+        //  [Siv3D]
+        //
+
         case FocusIn:
         {
             if (event->xfocus.mode == NotifyGrab ||
@@ -1857,6 +1870,9 @@ static void processEvent(XEvent *event)
             _glfwInputWindowFocus(window, GLFW_FALSE);
             return;
         }
+
+        //
+        //-----------------------------------------------
 
         case Expose:
         {
@@ -2000,6 +2016,11 @@ void _glfwPushSelectionToManagerX11(void)
 
 void _glfwCreateInputContextX11(_GLFWwindow* window)
 {
+    //-----------------------------------------------
+    //
+    //  [Siv3D]
+    //
+
     XIMCallback callback;
     callback.callback = (XIMProc) inputContextDestroyCallback;
     callback.client_data = (XPointer) window;
@@ -2020,6 +2041,9 @@ void _glfwCreateInputContextX11(_GLFWwindow* window)
                                NULL);
 
     XFree(preeditAttr);
+
+    //
+    //-----------------------------------------------
 
     if (window->x11.ic)
     {


### PR DESCRIPTION
- GLFWを一部改変し、XIMによる日本語入力に対応しました。
- 以下のLinux専用のAPIを実装しました。
  - IMEの有効/無効切り替え (`Platform::Linux::TextInput::EnableIME()`, `Platform::Linux::TextInput::DisableIME()`)
  - カーソル位置の取得 (`Platform::Linux::TextInput::GetCursorIndex()`)
  - 編集中文字列のスタイル取得 (`Platform::Linux::TextInput::GetEditingTextStyle()`)