### PR TITLE
HalfFloatに三方比較演算子を実装 (＋軽微な改善)

### DIFF
--- a/Siv3D/include/Siv3D/HalfFloat.hpp
+++ b/Siv3D/include/Siv3D/HalfFloat.hpp
@@ -13,6 +13,9 @@
 # if  __has_include(<bit>)
 #	include <bit>
 # endif
+# if  __has_include(<compare>)
+#	include <compare>
+# endif
 # include "Common.hpp"
 # include "Concepts.hpp"
 
@@ -43,8 +46,13 @@ namespace s3d
 		[[nodiscard]]
 		bool operator ==(const HalfFloat other) const noexcept;
 
+#if __cpp_impl_three_way_comparison
+		[[nodiscard]]
+		auto operator <=>(const HalfFloat other) const noexcept;
+#else
 		[[nodiscard]]
 		bool operator !=(const HalfFloat other) const noexcept;
+#endif
 
 		[[nodiscard]]
 		uint16 getBits() const noexcept;

--- a/Siv3D/include/Siv3D/detail/HalfFloat.ipp
+++ b/Siv3D/include/Siv3D/detail/HalfFloat.ipp
@@ -164,8 +164,8 @@ namespace s3d
 
 	inline bool HalfFloat::operator ==(const HalfFloat other) const noexcept
 	{
-		if (((m_bits << 1u) == 0)
-			&& ((other.m_bits << 1u) == 0))
+		if ((static_cast<uint16>(m_bits << 1u) == 0)
+			&& (static_cast<uint16>(other.m_bits << 1u) == 0))
 		{
 			return true;
 		}

--- a/Siv3D/include/Siv3D/detail/HalfFloat.ipp
+++ b/Siv3D/include/Siv3D/detail/HalfFloat.ipp
@@ -173,10 +173,17 @@ namespace s3d
 		return ((m_bits == other.m_bits) && (not isNaN()));
 	}
 
+#if __cpp_impl_three_way_comparison
+	inline auto HalfFloat::operator <=>(const HalfFloat other) const noexcept
+	{
+		return static_cast<float>(*this) <=> static_cast<float>(other);
+	}
+#else
 	inline bool HalfFloat::operator !=(const HalfFloat other) const noexcept
 	{
 		return !(operator ==(other));
 	}
+#endif
 
 	inline uint16 HalfFloat::getBits() const noexcept
 	{


### PR DESCRIPTION
テストコード:

```cpp
# include <Siv3D.hpp> // OpenSiv3D v0.6.2

void Main()
{
	assert(HalfFloat{ 1.0f } < HalfFloat{ 2.0f });
	assert(HalfFloat{ 1.0f } <= HalfFloat{ 2.0f });
	assert(HalfFloat{ 1.0f } <= HalfFloat{ 1.0f });
	assert(HalfFloat{ 1.0f } > HalfFloat{ -1.0f });
	assert(HalfFloat{ 1.0f } >= HalfFloat{ -1.0f });
	assert(HalfFloat{ 1.0f } >= HalfFloat{ 1.0f });
	assert(HalfFloat{ 1.0f } == HalfFloat{ 1.0f });
	assert(HalfFloat{ 0.0f } == HalfFloat{ -0.0f });
	assert(HalfFloat{ 1.0f } != HalfFloat{ 2.0f });
}
```

テストコードはここに書くので合ってるでしょうか？
(ユニットテストなどではなく)