### PR TITLE
String/StringView/UUIDValueに三方比較演算子を実装

### DIFF
--- a/Siv3D/include/Siv3D/String.hpp
+++ b/Siv3D/include/Siv3D/String.hpp
@@ -10,6 +10,9 @@
 //-----------------------------------------------
 
 # pragma once
+# if  __has_include(<compare>)
+#	include <compare>
+# endif
 # include <string>
 # include "Common.hpp"
 # include "StringView.hpp"
@@ -1129,13 +1132,21 @@ namespace s3d
 		/// @return 新しい文字列
 		String xml_escaped() const;
 
-
-		friend bool operator ==(const String& lhs, const String& rhs) noexcept;
-
-		friend bool operator ==(const value_type* lhs, const String& rhs);
-
 		friend bool operator ==(const String& lhs, const value_type* rhs);
 
+#if __cpp_impl_three_way_comparison
+
+		bool operator == (const String& rhs) const noexcept = default;
+
+		std::strong_ordering operator <=> (const String & rhs) const noexcept = default;
+
+		friend std::strong_ordering operator <=> (const String & lhs, const value_type * rhs);
+
+#else
+
+		friend bool operator ==(const String & lhs, const String & rhs) noexcept;
+
+		friend bool operator ==(const value_type * lhs, const String & rhs);
 
 		friend bool operator !=(const String& lhs, const String& rhs) noexcept;
 
@@ -1171,6 +1182,7 @@ namespace s3d
 
 		friend bool operator >=(const String& lhs, const value_type* rhs);
 
+#endif
 
 		friend String operator +(const value_type lhs, const String& rhs);
 

--- a/Siv3D/include/Siv3D/StringView.hpp
+++ b/Siv3D/include/Siv3D/StringView.hpp
@@ -10,6 +10,9 @@
 //-----------------------------------------------
 
 # pragma once
+# if  __has_include(<compare>)
+#	include <compare>
+# endif
 # include <iosfwd>
 # include <string_view>
 # include <string>
@@ -262,6 +265,13 @@ namespace s3d
 		[[nodiscard]]
 		uint64 hash() const noexcept;
 
+#if __cpp_impl_three_way_comparison
+
+		[[nodiscard]]
+		constexpr std::strong_ordering operator <=> (const StringView& rhs) const noexcept = default;
+
+#else
+
 		[[nodiscard]]
 		friend constexpr bool operator ==(StringView lhs, StringView rhs) noexcept
 		{
@@ -297,6 +307,8 @@ namespace s3d
 		{
 			return (lhs.compare(rhs) >= 0);
 		}
+
+#endif
 
 		friend std::ostream& operator <<(std::ostream& output, const StringView& value);
 

--- a/Siv3D/include/Siv3D/UUIDValue.hpp
+++ b/Siv3D/include/Siv3D/UUIDValue.hpp
@@ -11,6 +11,9 @@
 
 # pragma once
 # include <array>
+# if  __has_include(<compare>)
+#	include <compare>
+# endif
 # include "Common.hpp"
 # include "StringView.hpp"
 # include "Optional.hpp"
@@ -77,6 +80,13 @@ namespace s3d
 		[[nodiscard]]
 		size_t hash() const noexcept;
 
+#if __cpp_impl_three_way_comparison
+
+		[[nodiscard]]
+		std::strong_ordering operator <=>(const UUIDValue& rhs) const noexcept = default;
+
+#else
+
 		[[nodiscard]]
 		friend bool operator ==(const UUIDValue& lhs, const UUIDValue& rhs) noexcept
 		{
@@ -94,6 +104,8 @@ namespace s3d
 		{
 			return (lhs.m_data < rhs.m_data);
 		}
+
+#endif
 
 		[[nodiscard]]
 		static UUIDValue Generate();

--- a/Siv3D/src/Siv3D/String/SivString.cpp
+++ b/Siv3D/src/Siv3D/String/SivString.cpp
@@ -384,6 +384,20 @@ namespace s3d
 		return new_string;
 	}
 
+	bool operator ==(const String& lhs, const String::value_type* rhs)
+	{
+		return (lhs.str() == rhs);
+	}
+
+#if __cpp_impl_three_way_comparison
+
+	std::strong_ordering operator <=> (const String& lhs, const String::value_type* rhs)
+	{
+		return lhs.str() <=> rhs;
+	}
+
+#else
+
 	bool operator ==(const String& lhs, const String& rhs) noexcept
 	{
 		return (lhs.m_string == rhs.m_string);
@@ -392,11 +406,6 @@ namespace s3d
 	bool operator ==(const String::value_type* lhs, const String& rhs)
 	{
 		return (lhs == rhs.str());
-	}
-
-	bool operator ==(const String& lhs, const String::value_type* rhs)
-	{
-		return (lhs.str() == rhs);
 	}
 
 	bool operator !=(const String& lhs, const String& rhs) noexcept
@@ -473,6 +482,7 @@ namespace s3d
 	{
 		return (lhs.str() >= rhs);
 	}
+#endif
 
 	String operator +(const String::value_type lhs, const String& rhs)
 	{


### PR DESCRIPTION
Part of #658 

String
```cpp
assert(U"a"_s == U"a"_s);
assert(U"b"_s != U"a"_s);
assert(U"b"_s >  U"a"_s);
assert(U"b"_s >= U"a"_s);
assert(U"b"_s <  U"c"_s);
assert(U"b"_s <= U"c"_s);

assert(U"a" == U"a"_s);
assert(U"b" != U"a"_s);
assert(U"b" >  U"a"_s);
assert(U"b" >= U"a"_s);
assert(U"b" <  U"c"_s);
assert(U"b" <= U"c"_s);

assert(U"a"_s == U"a");
assert(U"b"_s != U"a");
assert(U"b"_s >  U"a");
assert(U"b"_s >= U"a");
assert(U"b"_s <  U"c");
assert(U"b"_s <= U"c");
```

StringView
```cpp
static_assert(U"a"_sv == U"a"_sv);
static_assert(U"b"_sv != U"a"_sv);
static_assert(U"b"_sv >  U"a"_sv);
static_assert(U"b"_sv >= U"a"_sv);
static_assert(U"b"_sv <  U"c"_sv);
static_assert(U"b"_sv <= U"c"_sv);

assert(U"a"_sv == U"a"_s);
assert(U"b"_s  != U"a"_sv);
assert(U"b"_sv >  U"a");
assert(U"b"    >= U"a"_s);
```

UUIDValue
```cpp
UUIDValue id1{ std::array<std::uint8_t, 16> { 0 } };
UUIDValue id2{ std::array<std::uint8_t, 16> { 1 } };
assert(id1 == id1);
assert(id1 != id2);
assert(id2 >  id1);
assert(id2 >= id1);
assert(id1 <  id2);
assert(id1 <= id2);
```