### PR TITLE
HalfFloatのすべてのメンバ関数をconstexprにする

### DIFF
--- a/Siv3D/include/Siv3D/HalfFloat.hpp
+++ b/Siv3D/include/Siv3D/HalfFloat.hpp
@@ -19,6 +19,14 @@
 # include "Common.hpp"
 # include "Concepts.hpp"
 
+// 定数式ではreinterpret_castができず、bit_castが必須のため、
+// bit_castが使えるときのみconstexprとするためのマクロ
+# if __cpp_lib_bit_cast
+# define SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE constexpr
+# else
+# define SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE
+# endif
+
 namespace s3d
 {
 	/// @brief 半精度浮動小数点数
@@ -30,43 +38,43 @@ namespace s3d
 		HalfFloat() = default;
 
 		SIV3D_NODISCARD_CXX20
-		HalfFloat(float value) noexcept;
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE HalfFloat(float value) noexcept;
 
 		SIV3D_CONCEPT_ARITHMETIC
-		HalfFloat(Arithmetic value) noexcept;
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE HalfFloat(Arithmetic value) noexcept;
 
-		HalfFloat& operator =(float value) noexcept;
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE HalfFloat& operator =(float value) noexcept;
 
 		SIV3D_CONCEPT_ARITHMETIC
-		HalfFloat& operator =(Arithmetic value);
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE HalfFloat& operator =(Arithmetic value);
 
 		[[nodiscard]]
-		operator float() const noexcept;
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE operator float() const noexcept;
 
 		[[nodiscard]]
-		bool operator ==(const HalfFloat other) const noexcept;
+		constexpr bool operator ==(const HalfFloat other) const noexcept;
 
 #if __cpp_impl_three_way_comparison
 		[[nodiscard]]
-		auto operator <=>(const HalfFloat other) const noexcept;
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE auto operator <=>(const HalfFloat other) const noexcept;
 #else
 		[[nodiscard]]
-		bool operator !=(const HalfFloat other) const noexcept;
+		constexpr bool operator !=(const HalfFloat other) const noexcept;
 #endif
 
 		[[nodiscard]]
-		uint16 getBits() const noexcept;
+		constexpr uint16 getBits() const noexcept;
 
-		void setBits(const uint16 bits) noexcept;
-
-		[[nodiscard]]
-		bool isNaN() const noexcept;
+		constexpr void setBits(const uint16 bits) noexcept;
 
 		[[nodiscard]]
-		bool isInfinity() const noexcept;
+		constexpr bool isNaN() const noexcept;
 
 		[[nodiscard]]
-		int32 getSign() const noexcept;
+		constexpr bool isInfinity() const noexcept;
+
+		[[nodiscard]]
+		constexpr int32 getSign() const noexcept;
 
 	private:
 
@@ -85,3 +93,5 @@ struct std::hash<s3d::HalfFloat>
 };
 
 # include "detail/HalfFloat.ipp"
+
+#undef SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE

--- a/Siv3D/include/Siv3D/detail/HalfFloat.ipp
+++ b/Siv3D/include/Siv3D/detail/HalfFloat.ipp
@@ -43,9 +43,9 @@ namespace s3d
 		//	CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
 		//	OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-		inline uint16 FloatToHalf(const float value) noexcept
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline uint16 FloatToHalf(const float value) noexcept
 		{
-			uint32 result;
+			uint32 result = 0;
 
 		# if __cpp_lib_bit_cast
 			uint32 iValue = std::bit_cast<uint32>(value);
@@ -92,7 +92,7 @@ namespace s3d
 			return static_cast<uint16>(result | sign);
 		}
 
-		inline float HalfToFloat(const uint16 value) noexcept
+		SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline float HalfToFloat(const uint16 value) noexcept
 		{
 			uint32 mantissa = static_cast<uint32>(value & 0x03FF);
 
@@ -139,30 +139,30 @@ namespace s3d
 		///////////////////////////////////////////////////////////////
 	}
 
-	inline HalfFloat::HalfFloat(const float value) noexcept
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline HalfFloat::HalfFloat(const float value) noexcept
 		: m_bits(detail::FloatToHalf(value)) {}
 
 	SIV3D_CONCEPT_ARITHMETIC_
-	inline HalfFloat::HalfFloat(const Arithmetic value) noexcept
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline HalfFloat::HalfFloat(const Arithmetic value) noexcept
 		: HalfFloat(static_cast<float>(value)) {}
 
-	inline HalfFloat& HalfFloat::operator =(const float value) noexcept
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline HalfFloat& HalfFloat::operator =(const float value) noexcept
 	{
 		return (*this = HalfFloat(value));
 	}
 
 	SIV3D_CONCEPT_ARITHMETIC_
-	inline HalfFloat& HalfFloat::operator =(const Arithmetic value)
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline HalfFloat& HalfFloat::operator =(const Arithmetic value)
 	{
 		return (*this = HalfFloat(value));
 	}
 
-	inline HalfFloat::operator float() const noexcept
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline HalfFloat::operator float() const noexcept
 	{
 		return detail::HalfToFloat(m_bits);
 	}
 
-	inline bool HalfFloat::operator ==(const HalfFloat other) const noexcept
+	constexpr inline bool HalfFloat::operator ==(const HalfFloat other) const noexcept
 	{
 		if ((static_cast<uint16>(m_bits << 1u) == 0)
 			&& (static_cast<uint16>(other.m_bits << 1u) == 0))
@@ -174,38 +174,38 @@ namespace s3d
 	}
 
 #if __cpp_impl_three_way_comparison
-	inline auto HalfFloat::operator <=>(const HalfFloat other) const noexcept
+	SIV3D_CONSTEXPR_IF_BITCAST_AVAILABLE inline auto HalfFloat::operator <=>(const HalfFloat other) const noexcept
 	{
 		return static_cast<float>(*this) <=> static_cast<float>(other);
 	}
 #else
-	inline bool HalfFloat::operator !=(const HalfFloat other) const noexcept
+	constexpr inline bool HalfFloat::operator !=(const HalfFloat other) const noexcept
 	{
 		return !(operator ==(other));
 	}
 #endif
 
-	inline uint16 HalfFloat::getBits() const noexcept
+	constexpr inline uint16 HalfFloat::getBits() const noexcept
 	{
 		return m_bits;
 	}
 
-	inline void HalfFloat::setBits(const uint16 bits) noexcept
+	constexpr inline void HalfFloat::setBits(const uint16 bits) noexcept
 	{
 		m_bits = bits;
 	}
 
-	inline bool HalfFloat::isNaN() const noexcept
+	constexpr inline bool HalfFloat::isNaN() const noexcept
 	{
 		return ((m_bits & 0x7FFFU) == 0x7FFFU);
 	}
 
-	inline bool HalfFloat::isInfinity() const noexcept
+	constexpr inline bool HalfFloat::isInfinity() const noexcept
 	{
 		return ((m_bits & 0x7FFFU) == 0x7C00U);
 	}
 
-	inline int32 HalfFloat::getSign() const noexcept
+	constexpr inline int32 HalfFloat::getSign() const noexcept
 	{
 		return ((m_bits & 0x8000U) ? -1 : 1);
 	}


### PR DESCRIPTION
```cpp
static_assert(HalfFloat{ 1.0f } < HalfFloat{ 2.0f });
static_assert(HalfFloat{ 1.0f } <= HalfFloat{ 2.0f });
static_assert(HalfFloat{ 1.0f } <= HalfFloat{ 1.0f });
static_assert(HalfFloat{ 1.0f } > HalfFloat{ -1.0f });
static_assert(HalfFloat{ 1.0f } >= HalfFloat{ -1.0f });
static_assert(HalfFloat{ 1.0f } >= HalfFloat{ 1.0f });
static_assert(HalfFloat{ 1.0f } == HalfFloat{ 1.0f });
static_assert(HalfFloat{ 0.0f } == HalfFloat{ -0.0f });
static_assert(HalfFloat{ 1.0f } != HalfFloat{ 2.0f });
```

※デフォルトコンストラクタはメンバー変数を初期化しないため、`constexpr`にしていません。これにより`float`と同じような使い勝手になります。