### PR TITLE
[共通] update ColorF

### DIFF
--- a/Siv3D/include/Siv3D/detail/ColorF.ipp
+++ b/Siv3D/include/Siv3D/detail/ColorF.ipp
@@ -270,7 +270,7 @@ namespace s3d
 				a + (other.a - a) * f };
 	}
 
-	inline ColorF ColorF::gamma(double gamma) const noexcept
+	inline ColorF ColorF::gamma(const double gamma) const noexcept
 	{
 		if (gamma <= 0.0)
 		{

--- a/Siv3D/include/Siv3D/detail/ColorF.ipp
+++ b/Siv3D/include/Siv3D/detail/ColorF.ipp
@@ -262,7 +262,7 @@ namespace s3d
 		return Max({ r, g, b ,a });
 	}
 
-	inline constexpr ColorF ColorF::lerp(const ColorF& other, double f) const noexcept
+	inline constexpr ColorF ColorF::lerp(const ColorF& other, const double f) const noexcept
 	{
 		return{ r + (other.r - r) * f,
 				g + (other.g - g) * f,


### PR DESCRIPTION
[Color.ipp](https://github.com/Siv3D/OpenSiv3D/blob/main/Siv3D/include/Siv3D/detail/Color.ipp) に対して [ColorF.ipp](https://github.com/Siv3D/OpenSiv3D/blob/main/Siv3D/include/Siv3D/detail/ColorF.ipp) の一部の関数の引数に const がついていなかったのを修正しました。