### PR TITLE
Camera2DParametersのパラメータをプラットフォームによって変える

### DIFF
--- a/Siv3D/src/Siv3D/Camera2DParameters/SivCamera2DParameters.cpp
+++ b/Siv3D/src/Siv3D/Camera2DParameters/SivCamera2DParameters.cpp
@@ -47,7 +47,11 @@ namespace s3d
 
 		if (cameraControl & CameraControl::Wheel)
 		{
+        	    # if defined(SIV3D_PLATFORM_WINDOWS)
 			params.wheelScaleFactor = 1.125;
+	            # elif defined(SIV3D_PLATFORM_MACOS)
+        	    	params.wheelScaleFactor = 1.075;
+	            # endif
 		}
 		
 		return params;


### PR DESCRIPTION
MacでCamera2Dを使っているときにズームが少し過剰では？と思ったので、WinとMacで分けられたらいいなぁと思いました。
試してみて、Macだとこのくらいの値が最適かと思います