### PR TITLE
Rect, RectFに各辺のxもしくはy座標を取得するメソッドの追加

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Developers:
     mak1a
     Satoshi Tanaka
     k-sunako
+    Takacie
 
 Document Authors:
     Ryo Suzuki

--- a/Siv3D/include/Siv3D/Rect.hpp
+++ b/Siv3D/include/Siv3D/Rect.hpp
@@ -580,6 +580,26 @@ namespace s3d
 		[[nodiscard]]
 		constexpr Line left() const noexcept;
 
+		/// @brief 長方形の上辺のy座標を value_type として返します。
+		/// @return 長方形の上辺のy座標
+		[[nodiscard]]
+		constexpr value_type topY() const noexcept;
+
+		/// @brief 長方形の右辺のx座標を value_type として返します。
+		/// @return 長方形の右辺のx座標
+		[[nodiscard]]
+		constexpr value_type rightX() const noexcept;
+
+		/// @brief 長方形の下辺のy座標を value_type として返します。
+		/// @return 長方形の下辺のy座標
+		[[nodiscard]]
+		constexpr value_type bottomY() const noexcept;
+
+		/// @brief 長方形の左辺のx座標を value_type として返します。
+		/// @return 長方形の左辺のx座標
+		[[nodiscard]]
+		constexpr value_type leftX() const noexcept;
+
 		[[nodiscard]]
 		constexpr position_type point(size_t index) const;
 

--- a/Siv3D/include/Siv3D/RectF.hpp
+++ b/Siv3D/include/Siv3D/RectF.hpp
@@ -587,6 +587,26 @@ namespace s3d
 		[[nodiscard]]
 		constexpr Line left() const noexcept;
 
+		/// @brief 長方形の上辺のy座標を value_type として返します。
+		/// @return 長方形の上辺のy座標
+		[[nodiscard]]
+		constexpr value_type topY() const noexcept;
+
+		/// @brief 長方形の右辺のx座標を value_type として返します。
+		/// @return 長方形の右辺のx座標
+		[[nodiscard]]
+		constexpr value_type rightX() const noexcept;
+
+		/// @brief 長方形の下辺のy座標を value_type として返します。
+		/// @return 長方形の下辺のy座標
+		[[nodiscard]]
+		constexpr value_type bottomY() const noexcept;
+
+		/// @brief 長方形の左辺のx座標を value_type として返します。
+		/// @return 長方形の左辺のx座標
+		[[nodiscard]]
+		constexpr value_type leftX() const noexcept;
+
 		[[nodiscard]]
 		constexpr position_type point(size_t index) const;
 

--- a/Siv3D/include/Siv3D/detail/Rect.ipp
+++ b/Siv3D/include/Siv3D/detail/Rect.ipp
@@ -686,6 +686,26 @@ namespace s3d
 		return{ bl(), tl() };
 	}
 
+	inline constexpr Rect::value_type Rect::topY() const noexcept
+	{
+		return y;
+	}
+
+	inline constexpr Rect::value_type Rect::rightX() const noexcept
+	{
+		return (x + w);
+	}
+
+	inline constexpr Rect::value_type Rect::bottomY() const noexcept
+	{
+		return (y + h);
+	}
+
+	inline constexpr Rect::value_type Rect::leftX() const noexcept
+	{
+		return x;
+	}
+
 	inline constexpr Rect::position_type Rect::point(const size_t index) const
 	{
 		if (index == 0)

--- a/Siv3D/include/Siv3D/detail/RectF.ipp
+++ b/Siv3D/include/Siv3D/detail/RectF.ipp
@@ -1,4 +1,5 @@
-﻿//-----------------------------------------------
+﻿#include "..\RectF.hpp"
+//-----------------------------------------------
 //
 //	This file is part of the Siv3D Engine.
 //
@@ -695,6 +696,26 @@ namespace s3d
 	inline constexpr Line RectF::left() const noexcept
 	{
 		return{ bl(), tl() };
+	}
+
+	inline constexpr RectF::value_type RectF::topY() const noexcept
+	{
+		return y;
+	}
+
+	inline constexpr RectF::value_type RectF::rightX() const noexcept
+	{
+		return (x + w);
+	}
+
+	inline constexpr RectF::value_type RectF::bottomY() const noexcept
+	{
+		return (y + h);
+	}
+
+	inline constexpr RectF::value_type RectF::leftX() const noexcept
+	{
+		return x;
 	}
 
 	inline constexpr RectF::position_type RectF::point(const size_t index) const

--- a/WindowsDesktop/Main.cpp
+++ b/WindowsDesktop/Main.cpp
@@ -5,55 +5,24 @@ void Main()
 	// 背景の色を設定 | Set background color
 	Scene::SetBackground(ColorF{ 0.8, 0.9, 1.0 });
 
-	// 通常のフォントを作成 | Create a new font
-	const Font font{ 60 };
-
-	// 絵文字用フォントを作成 | Create a new emoji font
-	const Font emojiFont{ 60, Typeface::ColorEmoji };
-
-	// `font` が絵文字用フォントも使えるようにする | Set emojiFont as a fallback
-	font.addFallback(emojiFont);
-
-	// 画像ファイルからテクスチャを作成 | Create a texture from an image file
-	const Texture texture{ U"example/windmill.png" };
-
-	// 絵文字からテクスチャを作成 | Create a texture from an emoji
-	const Texture emoji{ U"🐈"_emoji };
-
-	// 絵文字を描画する座標 | Coordinates of the emoji
-	Vec2 emojiPos{ 300, 150 };
-
-	// テキストを画面にデバッグ出力 | Print a text
-	Print << U"Push [A] key";
+	Rect rect{ 36, 42, 100, 100 };
+	RectF rectF{ 236, 242, 100, 100 };
 
 	while (System::Update())
 	{
-		// テクスチャを描く | Draw a texture
-		texture.draw(200, 200);
+		ClearPrint();
 
-		// テキストを画面の中心に描く | Put a text in the middle of the screen
-		font(U"Hello, Siv3D!🚀").drawAt(Scene::Center(), Palette::Black);
-
-		// サイズをアニメーションさせて絵文字を描く | Draw a texture with animated size
-		emoji.resized(100 + Periodic::Sine0_1(1s) * 20).drawAt(emojiPos);
-
-		// マウスカーソルに追随する半透明な円を描く | Draw a red transparent circle that follows the mouse cursor
-		Circle{ Cursor::Pos(), 40 }.draw(ColorF{ 1, 0, 0, 0.5 });
-
-		// もし [A] キーが押されたら | When [A] key is down
-		if (KeyA.down())
-		{
-			// 選択肢からランダムに選ばれたメッセージをデバッグ表示 | Print a randomly selected text
-			Print << Sample({ U"Hello!", U"こんにちは", U"你好", U"안녕하세요?" });
-		}
-
-		// もし [Button] が押されたら | When [Button] is pushed
-		if (SimpleGUI::Button(U"Button", Vec2{ 640, 40 }))
-		{
-			// 画面内のランダムな場所に座標を移動
-			// Move the coordinates to a random position in the screen
-			emojiPos = RandomVec2(Scene::Rect());
-		}
+		Print << U"-- Rect Test --";
+		Print << U"topY(): " << rect.topY();        // 42
+		Print << U"leftX(): " << rect.leftX();      // 36
+		Print << U"bottomY(): " << rect.bottomY();  // 142
+		Print << U"rightX(): " << rect.rightX();    // 136
+		Print << U"";
+		Print << U"-- RectF Test --";
+		Print << U"topY(): " << rectF.topY();       // 242
+		Print << U"leftX(): " << rectF.leftX();     // 236
+		Print << U"bottomY(): " << rectF.bottomY(); // 342
+		Print << U"rightX(): " << rectF.rightX();   // 336
 	}
 }
 


### PR DESCRIPTION
Rect, RectFにおいて、左辺・右辺のx座標、上辺・下辺のy座標を取得できるメソッドがあるといいなと思ったのですが、いかがでしょう？（左辺、上辺に関してはRect::x, Rect::yを返すだけなので必要ないかもしれません）

```C++
Rect rect{ 36, 42, 100, 100 };
RectF rectF{ 236, 242, 100, 100 };

while (System::Update())
{
  ClearPrint();
  
  Print << U"-- Rect Test --";
  Print << U"topY(): " << rect.topY();        // 42
  Print << U"leftX(): " << rect.leftX();      // 36
  Print << U"bottomY(): " << rect.bottomY();  // 142
  Print << U"rightX(): " << rect.rightX();    // 136
  Print << U"";
  Print << U"-- RectF Test --";
  Print << U"topY(): " << rectF.topY();       // 242
  Print << U"leftX(): " << rectF.leftX();     // 236
  Print << U"bottomY(): " << rectF.bottomY(); // 342
  Print << U"rightX(): " << rectF.rightX();   // 336
}
```