### PR TITLE
Linux CI の更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         config:
           - runs-on: ubuntu-20.04
             install-compiler-command:
-            cmake-env-vars:
+            cmake-additional-flags:
             boost-package: libboost1.71-dev
           - runs-on: ubuntu-20.04
             install-compiler-command: sudo apt install clang-11
-            cmake-env-vars: CC=/usr/bin/clang CXX=/usr/bin/clang++
+            cmake-additional-flags: -DCMAKE_CXX_COMPILER=clang-11 -DCMAKE_C_COMPILER=clang-11
             boost-package: libboost1.71-dev
 
     runs-on: ${{ matrix.config.runs-on }}
@@ -68,7 +68,7 @@ jobs:
       working-directory: Linux
       run: |
         mkdir build && cd build
-        ${{ matrix.config.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        cmake ${{ matrix.config.cmake-additional-flags }} -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3D
       working-directory: Linux
@@ -79,7 +79,7 @@ jobs:
       working-directory: Linux/App
       run: |
         mkdir build && cd build
-        ${{ matrix.config.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        cmake ${{ matrix.config.cmake-additional-flags }} -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3DTest
       working-directory: Linux/App
@@ -90,5 +90,5 @@ jobs:
       working-directory: Linux/App
       run: |
         cd build
-        ${{ matrix.config.cmake-env-vars }} cmake -DBUILD_TESTING:BOOL=ON .
+        cmake ${{ matrix.config.cmake-additional-flags }} -DBUILD_TESTING:BOOL=ON .
         ctest --output-on-failure --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,28 @@ on:
     branches:
     - main
     - v6_develop
+    - v6_linux_*
   pull_request:
     branches:
     - main
     - v6_develop
+    - v6_linux_*
 
 jobs:
   Linux:
 
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        - runs-on: ubuntu-20.04
+          install-compiler-command:
+          cmake-env-vars:
+          boost-package: libboost1.71-dev
+        - runs-on: ubuntu-20.04
+          install-compiler-command: sudo apt install clang-11-dev
+          cmake-env-vars: CC=/usr/bin/clang CXX=/usr/bin/clang++
+          boost-package: libboost1.71-dev
+
+    runs-on: ${{ matrix.runs-on }}
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
@@ -23,12 +36,13 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt update
+        ${{ matrix.install-compiler-command }}
         sudo apt install ninja-build
         sudo apt install libasound2-dev
         sudo apt install libavcodec-dev
         sudo apt install libavformat-dev
         sudo apt install libavutil-dev
-        sudo apt install libboost-dev
+        sudo apt install ${{ matrix.boost-package }}
         sudo apt install libcurl4-openssl-dev
         sudo apt install libgtk-3-dev
         sudo apt install libgif-dev
@@ -52,7 +66,7 @@ jobs:
       working-directory: Linux
       run: |
         mkdir build && cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        ${{ matrix.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3D
       working-directory: Linux
@@ -63,7 +77,7 @@ jobs:
       working-directory: Linux/App
       run: |
         mkdir build && cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        ${{ matrix.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3DTest
       working-directory: Linux/App
@@ -74,5 +88,5 @@ jobs:
       working-directory: Linux/App
       run: |
         cd build
-        cmake -DBUILD_TESTING:BOOL=ON .
+        ${{ matrix.cmake-env-vars }} cmake -DBUILD_TESTING:BOOL=ON .
         ctest --output-on-failure --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,17 @@ jobs:
 
     strategy:
       matrix:
-        - runs-on: ubuntu-20.04
-          install-compiler-command:
-          cmake-env-vars:
-          boost-package: libboost1.71-dev
-        - runs-on: ubuntu-20.04
-          install-compiler-command: sudo apt install clang-11-dev
-          cmake-env-vars: CC=/usr/bin/clang CXX=/usr/bin/clang++
-          boost-package: libboost1.71-dev
+        config:
+          - runs-on: ubuntu-20.04
+            install-compiler-command:
+            cmake-env-vars:
+            boost-package: libboost1.71-dev
+          - runs-on: ubuntu-20.04
+            install-compiler-command: sudo apt install clang-11-dev
+            cmake-env-vars: CC=/usr/bin/clang CXX=/usr/bin/clang++
+            boost-package: libboost1.71-dev
 
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.config.runs-on }}
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     steps:
@@ -36,13 +37,13 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt update
-        ${{ matrix.install-compiler-command }}
+        ${{ matrix.config.install-compiler-command }}
         sudo apt install ninja-build
         sudo apt install libasound2-dev
         sudo apt install libavcodec-dev
         sudo apt install libavformat-dev
         sudo apt install libavutil-dev
-        sudo apt install ${{ matrix.boost-package }}
+        sudo apt install ${{ matrix.config.boost-package }}
         sudo apt install libcurl4-openssl-dev
         sudo apt install libgtk-3-dev
         sudo apt install libgif-dev
@@ -66,7 +67,7 @@ jobs:
       working-directory: Linux
       run: |
         mkdir build && cd build
-        ${{ matrix.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        ${{ matrix.config.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3D
       working-directory: Linux
@@ -77,7 +78,7 @@ jobs:
       working-directory: Linux/App
       run: |
         mkdir build && cd build
-        ${{ matrix.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        ${{ matrix.config.cmake-env-vars }} cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 
     - name: Build Siv3DTest
       working-directory: Linux/App
@@ -88,5 +89,5 @@ jobs:
       working-directory: Linux/App
       run: |
         cd build
-        ${{ matrix.cmake-env-vars }} cmake -DBUILD_TESTING:BOOL=ON .
+        ${{ matrix.config.cmake-env-vars }} cmake -DBUILD_TESTING:BOOL=ON .
         ctest --output-on-failure --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             cmake-env-vars:
             boost-package: libboost1.71-dev
           - runs-on: ubuntu-20.04
-            install-compiler-command: sudo apt install clang-11-dev
+            install-compiler-command: sudo apt install clang-11
             cmake-env-vars: CC=/usr/bin/clang CXX=/usr/bin/clang++
             boost-package: libboost1.71-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   Linux:
 
     strategy:
+      fail-fast: false
       matrix:
         config:
           - runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
             install-compiler-command:
             cmake-additional-flags:
             boost-package: libboost1.71-dev
-          - runs-on: ubuntu-20.04
-            install-compiler-command: sudo apt install clang-11
-            cmake-additional-flags: -DCMAKE_CXX_COMPILER=clang-11 -DCMAKE_C_COMPILER=clang-11
-            boost-package: libboost1.71-dev
+          - runs-on: ubuntu-22.04
+            install-compiler-command:
+            cmake-additional-flags:
+            boost-package: libboost1.74-dev
+          - runs-on: ubuntu-22.04
+            install-compiler-command:
+            cmake-additional-flags: -DCMAKE_CXX_COMPILER=clang-14 -DCMAKE_C_COMPILER=clang-14
+            boost-package: libboost1.74-dev
 
     runs-on: ${{ matrix.config.runs-on }}
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"


### PR DESCRIPTION
OpenSiv3D for Linux のサポート強化のために、各ディストリビューション/バージョンでのビルドを行う CI を追加する更新です。

**Ubuntu**

- [x] Ubuntu 20.04 + GCC 9.3 + Boost 1.71.0
- [x] Ubuntu 22.04 + GCC 11.2 + Boost 1.74.0
- [x] Ubuntu 22.04 + Clang 14.0.0 + Boost 1.74.0
  - GitHub workflows で Ubuntu 22.04 が利用できるようになるまで待ち
  - <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources>

**そのほかディストリビューション**

- Docker コンテナを使えば何とかなる？
  - GitHub workflows では amd64 以外のアーキテクチャのビルドができなさそう 
