### PR TITLE
Fix #778

### DIFF
--- a/Siv3D/include/Siv3D/OpenCV_Bridge.hpp
+++ b/Siv3D/include/Siv3D/OpenCV_Bridge.hpp
@@ -54,7 +54,7 @@ namespace s3d
 		inline cv::Rect ToCVRect(const Rect& rect);
 
 		[[nodiscard]]
-		inline cv::Mat_<cv::Vec4b> GetMatView(Image& image);
+		inline cv::Mat GetMatView(Image& image);
 
 		[[nodiscard]]
 		inline constexpr int32 ConvertBorderType(const BorderType borderType) noexcept;

--- a/Siv3D/include/Siv3D/detail/OpenCV_Bridge.ipp
+++ b/Siv3D/include/Siv3D/detail/OpenCV_Bridge.ipp
@@ -22,7 +22,7 @@ namespace s3d
 
 		inline cv::Mat GetMatView(Image& image)
 		{
-			return{ cv::Size{ image.width(), image.height() }, CV_8UC4, const_cast<uint8*>(image.dataAsUint8()), image.stride() };
+			return{ cv::Size{ image.width(), image.height() }, CV_8UC4, image.dataAsUint8(), image.stride() };
 		}
 
 		inline constexpr int32 ConvertBorderType(const BorderType borderType) noexcept

--- a/Siv3D/include/Siv3D/detail/OpenCV_Bridge.ipp
+++ b/Siv3D/include/Siv3D/detail/OpenCV_Bridge.ipp
@@ -20,9 +20,9 @@ namespace s3d
 			return{ rect.x, rect.y, rect.w, rect.h };
 		}
 
-		inline cv::Mat_<cv::Vec4b> GetMatView(Image& image)
+		inline cv::Mat GetMatView(Image& image)
 		{
-			return{ image.height(), image.width(), static_cast<cv::Vec4b*>(static_cast<void*>(image.data())), image.stride() };
+			return{ cv::Size{ image.width(), image.height() }, CV_8UC4, const_cast<uint8*>(image.dataAsUint8()), image.stride() };
 		}
 
 		inline constexpr int32 ConvertBorderType(const BorderType borderType) noexcept

--- a/Siv3D/src/Siv3D/Image/ImagePainting.cpp
+++ b/Siv3D/src/Siv3D/Image/ImagePainting.cpp
@@ -706,7 +706,7 @@ namespace s3d
 			return *this;
 		}
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 		cv::line(mat,
 			{ static_cast<int32>(begin.x), static_cast<int32>(begin.y) },
 			{ static_cast<int32>(end.x), static_cast<int32>(end.y) },
@@ -1380,7 +1380,7 @@ namespace s3d
 			cv::Point(static_cast<int32>(p2.x), static_cast<int32>(p2.y)),
 		};
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 		cv::fillConvexPoly(mat, pts, 3, cv::Scalar(color.r, color.g, color.b, color.a), (antialiased ? cv::LINE_AA : cv::LINE_8));
 
 		return *this;
@@ -1422,7 +1422,7 @@ namespace s3d
 			cv::Point(static_cast<int32>(p3.x), static_cast<int32>(p3.y)),
 		};
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 		cv::fillConvexPoly(mat, pts, 4, cv::Scalar(color.r, color.g, color.b, color.a), antialiased ? cv::LINE_AA : cv::LINE_8);
 
 		return *this;
@@ -1462,7 +1462,7 @@ namespace s3d
 			++holeIndex;
 		}
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 
 		Array<const Point*> ppts;
 		{
@@ -1537,7 +1537,7 @@ namespace s3d
 			++holeIndex;
 		}
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 
 		Array<const Point*> ppts;
 		{
@@ -1607,7 +1607,7 @@ namespace s3d
 			++holeIndex;
 		}
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 
 		Array<const cv::Point*> ppts;
 		{
@@ -1675,7 +1675,7 @@ namespace s3d
 			++holeIndex;
 		}
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 
 		Array<const cv::Point*> ppts;
 		{
@@ -1762,7 +1762,7 @@ namespace s3d
 		const cv::Point* ptr = points.data();
 		const cv::Point** pptr = &ptr;
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 		cv::polylines(mat, pptr, &n, 1, false, cv::Scalar(color.r, color.g, color.b, color.a), thickness, (antialiased ? cv::LINE_AA : cv::LINE_8));
 
 		return *this;
@@ -1786,7 +1786,7 @@ namespace s3d
 		const cv::Point* ptr = points.data();
 		const cv::Point** pptr = &ptr;
 
-		cv::Mat_<cv::Vec4b> mat = OpenCV_Bridge::GetMatView(dst);
+		cv::Mat mat = OpenCV_Bridge::GetMatView(dst);
 		cv::polylines(mat, pptr, &n, 1, true, cv::Scalar(color.r, color.g, color.b, color.a), thickness, (antialiased ? cv::LINE_AA : cv::LINE_8));
 
 		return *this;

--- a/Siv3D/src/Siv3D/Image/SivImage.cpp
+++ b/Siv3D/src/Siv3D/Image/SivImage.cpp
@@ -1662,7 +1662,7 @@ namespace s3d
 
 		// 2. 処理
 		{
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
 			cv::blur(matSrc, matSrc, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), cv::Point(-1, -1), OpenCV_Bridge::ConvertBorderType(borderType));
 		}
 
@@ -1692,8 +1692,8 @@ namespace s3d
 		// 2. 処理
 		{
 			Image image{ m_width, m_height };
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::blur(matSrc, matDst, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), cv::Point(-1, -1), OpenCV_Bridge::ConvertBorderType(borderType));
 			return image;
@@ -1722,7 +1722,7 @@ namespace s3d
 
 		// 2. 処理
 		{
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
 			cv::medianBlur(matSrc, matSrc, apertureSize);
 		}
 
@@ -1752,8 +1752,8 @@ namespace s3d
 		// 2. 処理
 		{
 			Image image{ m_width, m_height };
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::medianBlur(matSrc, matDst, apertureSize);
 			return image;
@@ -1782,7 +1782,7 @@ namespace s3d
 
 		// 2. 処理
 		{
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
 			cv::GaussianBlur(matSrc, matSrc, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), 0.0, 0.0, OpenCV_Bridge::ConvertBorderType(borderType));
 		}
 
@@ -1812,8 +1812,8 @@ namespace s3d
 		// 2. 処理
 		{
 			Image image{ m_width, m_height };
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::GaussianBlur(matSrc, matDst, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), 0.0, 0.0, OpenCV_Bridge::ConvertBorderType(borderType));
 			return image;
@@ -1880,7 +1880,7 @@ namespace s3d
 
 		// 2. 処理
 		{
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
 			cv::dilate(matSrc, matSrc, cv::Mat(), cv::Point(-1, -1), iterations);
 		}
 
@@ -1905,8 +1905,8 @@ namespace s3d
 		// 2. 処理
 		{
 			Image image{ m_width, m_height };
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::dilate(matSrc, matDst, cv::Mat(), cv::Point(-1, -1), iterations);
 			return image;
@@ -1930,7 +1930,7 @@ namespace s3d
 
 		// 2. 処理
 		{
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
 			cv::erode(matSrc, matSrc, cv::Mat(), cv::Point(-1, -1), iterations);
 		}
 
@@ -1955,8 +1955,8 @@ namespace s3d
 		// 2. 処理
 		{
 			Image image{ m_width, m_height };
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::erode(matSrc, matDst, cv::Mat(), cv::Point(-1, -1), iterations);
 			return image;
@@ -2076,8 +2076,8 @@ namespace s3d
 			}
 
 			Image tmp(targetWidth, targetHeight);
-			const cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(*this);
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(tmp);
+			const cv::Mat matSrc = OpenCV_Bridge::GetMatView(*this);
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(tmp);
 			
 			cv::resize(matSrc, matDst, matDst.size(), 0, 0, static_cast<int32>(interpolation));
 			swap(tmp);
@@ -2127,8 +2127,8 @@ namespace s3d
 			}
 
 			Image image(targetWidth, targetHeight);
-			const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
-			cv::Mat_<cv::Vec4b> matDst = OpenCV_Bridge::GetMatView(image);
+			const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
+			cv::Mat matDst = OpenCV_Bridge::GetMatView(image);
 
 			cv::resize(matSrc, matDst, matDst.size(), 0, 0, static_cast<int32>(interpolation));
 			return image;
@@ -2335,7 +2335,7 @@ namespace s3d
 		const Size dstSize = Math::Ceil(boundingRect.size).asPoint();
 
 		const cv::Matx23f transform{ m._11, m._21, m._31, m._12, m._22, m._32 };
-		const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
+		const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
 		cv::Mat_<cv::Vec4b> matDst;
 
 		const ColorF bg{ background };
@@ -2378,7 +2378,7 @@ namespace s3d
 		};
 
 		const cv::Mat transform = cv::getPerspectiveTransform(from, to);
-		const cv::Mat_<cv::Vec4b> matSrc(m_height, m_width, const_cast<cv::Vec4b*>(static_cast<const cv::Vec4b*>(static_cast<const void*>(data()))), stride());
+		const cv::Mat matSrc(cv::Size(m_width, m_height), CV_8UC4, const_cast<uint8*>(dataAsUint8()), stride());
 		cv::Mat_<cv::Vec4b> matDst;
 
 		const ColorF bg{ background };

--- a/Siv3D/src/Siv3D/ImageROI/SivImageROI.cpp
+++ b/Siv3D/src/Siv3D/ImageROI/SivImageROI.cpp
@@ -369,7 +369,7 @@ namespace s3d
 		// 2. 処理
 		{
 			const cv::Rect roi = OpenCV_Bridge::ToCVRect(region);
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(imageRef);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(imageRef);
 			cv::Mat srcROI = matSrc(roi);
 
 			cv::blur(srcROI, srcROI, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), cv::Point(-1, -1), OpenCV_Bridge::ConvertBorderType(borderType));
@@ -401,7 +401,7 @@ namespace s3d
 		// 2. 処理
 		{
 			const cv::Rect roi = OpenCV_Bridge::ToCVRect(region);
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(imageRef);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(imageRef);
 			cv::Mat srcROI = matSrc(roi);
 
 			cv::medianBlur(srcROI, srcROI, apertureSize);
@@ -434,7 +434,7 @@ namespace s3d
 		// 2. 処理
 		{
 			const cv::Rect roi = OpenCV_Bridge::ToCVRect(region);
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(imageRef);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(imageRef);
 			cv::Mat srcROI = matSrc(roi);
 
 			cv::GaussianBlur(srcROI, srcROI, cv::Size(horizontal * 2 + 1, vertical * 2 + 1), 0.0, 0.0, OpenCV_Bridge::ConvertBorderType(borderType));
@@ -466,7 +466,7 @@ namespace s3d
 		// 2. 処理
 		{
 			const cv::Rect roi = OpenCV_Bridge::ToCVRect(region);
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(imageRef);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(imageRef);
 			cv::Mat srcROI = matSrc(roi);
 
 			cv::dilate(srcROI, srcROI, cv::Mat(), cv::Point(-1, -1), iterations);
@@ -493,7 +493,7 @@ namespace s3d
 		// 2. 処理
 		{
 			const cv::Rect roi = OpenCV_Bridge::ToCVRect(region);
-			cv::Mat_<cv::Vec4b> matSrc = OpenCV_Bridge::GetMatView(imageRef);
+			cv::Mat matSrc = OpenCV_Bridge::GetMatView(imageRef);
 			cv::Mat srcROI = matSrc(roi);
 
 			cv::erode(srcROI, srcROI, cv::Mat(), cv::Point(-1, -1), iterations);


### PR DESCRIPTION
#778 を修正しました。主な変更は次の通りです。
- ``cv::Mat_<cv::Vec4b>``の一部を``cv::Mat``に変更しました。
- ``GetMatView``の実装を変更しました。


``GetMatView``は以下のように変更しました。
```
inline cv::Mat GetMatView(Image& image)
{
	return{ cv::Size{ image.width(), image.height() }, CV_8UC4, const_cast<uint8*>(image.dataAsUint8()), image.stride() };
}
```

これにより、Imageの`blur`, `dilate`, `erode`, `rotated`と`scaled`が正常に動作するようになりました。