### PR TITLE
算術型から BigInt/BigFloat を引くときの無駄なコピーを回避

### DIFF
--- a/Siv3D/include/Siv3D/BigFloat.hpp
+++ b/Siv3D/include/Siv3D/BigFloat.hpp
@@ -262,7 +262,7 @@ namespace s3d
 		[[nodiscard]]
 		friend inline BigFloat operator -(Arithmetic a, const BigFloat& b)
 		{
-			return (-b + a);
+			return -(b - a);
 		}
 
 		//////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/BigInt.hpp
+++ b/Siv3D/include/Siv3D/BigInt.hpp
@@ -207,7 +207,7 @@ namespace s3d
 		[[nodiscard]]
 		friend inline BigInt operator -(const Int a, const BigInt& b)
 		{
-			return (-b + a);
+			return -(b - a);
 		}
 
 		//////////////////////////////////////////////////


### PR DESCRIPTION
`BigInt`/`BigFloat` と算術型（ `BigInt` の場合は整数型に限る）の引き算で、 `-` の前後を入れ替えただけで実行速度が大きく変わっていたので、実行速度の差が小さくなるように変更しました。

`BigInt` について、変更前の `-b + a` では `BigInt::operator-() const&` で1回、 `BigInt::operator+(decltype(a))` で1回コピーされるのに対して、変更後の `-(b - a)` では `BigInt::operator-(decltype(a))` で1回コピーされ、 `BigInt::operator-() &&` ではコピーされないため、無駄な2回目のコピーを回避できます（ `BigFloat` についても同様）。

---

```c++
# include <Siv3D.hpp>

void Main()
{
	constexpr int iteration = 10'000'000;
	BigInt x = 12345678901234567890_big;
	Stopwatch stopwatch;

	stopwatch.start();
	for ([[maybe_unused]] auto i : Iota(iteration))
	{
		void(x - 1234567890);
	}
	stopwatch.pause();
	Console << U"BigInt - Int: {} [us]"_fmt(stopwatch.us());

	stopwatch.restart();
	for ([[maybe_unused]] auto i : Iota(iteration))
	{
		void(1234567890 - x);
	}
	stopwatch.pause();
	Console << U"Int - BigInt: {} [us]"_fmt(stopwatch.us());

	while (System::Update());
}
```

実行結果例（変更前）
```
BigInt - Int: 791161 [us]
Int - BigInt: 1542907 [us]
```

実行結果例（変更後）
```
BigInt - Int: 765885 [us]
Int - BigInt: 843699 [us]
```