### PR TITLE
String::removed()の引数に空文字を渡した時の挙動を修正

### DIFF
--- a/Siv3D/src/Siv3D/String/SivString.cpp
+++ b/Siv3D/src/Siv3D/String/SivString.cpp
@@ -454,6 +454,11 @@ namespace s3d
 
 	String String::removed(const StringView s) const
 	{
+		if (s.isEmpty())
+		{
+			return *this;
+		}
+
 		String result;
 
 		for (auto it = begin(); it != end();)


### PR DESCRIPTION
### 変更内容

`String::removed(const StringView s)`の引数`s`に空文字を渡した時、
無限ループになってしまう挙動を修正しました。

この挙動は以下のようなコードで再現できます。
```
# include <Siv3D.hpp> // OpenSiv3D v0.6.5

void Main()
{
	String original = U"apple";
	String removed = original.removed(U"");

	Print << original;
	Print << removed;

	while (System::Update())
	{
	}
}
```

### その他
今回初めてのpull requestです。
何か誤ったことをしていた場合はご指摘ください。
