### PR TITLE
時間型を fmt に対応

### DIFF
--- a/Siv3D/include/Siv3D/Duration.hpp
+++ b/Siv3D/include/Siv3D/Duration.hpp
@@ -14,6 +14,8 @@
 # include "Common.hpp"
 # include "Fwd.hpp"
 # include "StringView.hpp"
+# include "Format.hpp"
+# include "FormatLiteral.hpp"
 
 namespace s3d
 {
@@ -186,5 +188,33 @@ namespace s3d
 	/// @param nanoseconds ナノ秒
 	void Formatter(FormatData& formatData, const NanosecondsF& nanoseconds);
 }
+
+template <class Rep, class Period>
+struct SIV3D_HIDDEN fmt::formatter<std::chrono::duration<Rep, Period>, s3d::char32>
+{
+	std::u32string tag;
+
+	auto parse(basic_format_parse_context<s3d::char32>& ctx)
+	{
+		return s3d::detail::GetFormatTag(tag, ctx);
+	}
+
+	template <class FormatContext>
+	auto format(const std::chrono::duration<Rep, Period>& value, FormatContext& ctx)
+	{
+		const s3d::String s = s3d::Format(value);
+		const basic_string_view<s3d::char32> sv(s.data(), s.size());
+
+		if (tag.empty())
+		{
+			return format_to(ctx.out(), U"{}", sv);
+		}
+		else
+		{
+			const std::u32string format = (U"{:" + tag + U'}');
+			return format_to(ctx.out(), format, sv);
+		}
+	}
+};
 
 # include "detail/Duration.ipp"


### PR DESCRIPTION
#894 の PR です。

```c++
# include <Siv3D.hpp>

void Main()
{
	assert(U"{}"_fmt(42_d) == U"42d");
	assert(U"{}"_fmt(3.14_d) == U"3.14d");
	assert(U"{}"_fmt(42h) == U"42h");
	assert(U"{}"_fmt(3.14h) == U"3.14h");
	assert(U"{}"_fmt(42min) == U"42min");
	assert(U"{}"_fmt(3.14min) == U"3.14min");
	assert(U"{}"_fmt(42s) == U"42s");
	assert(U"{}"_fmt(3.14s) == U"3.14s");
	assert(U"{}"_fmt(42ms) == U"42ms");
	assert(U"{}"_fmt(3.14ms) == U"3.14ms");
	assert(U"{}"_fmt(42us) == U"42us");
	assert(U"{}"_fmt(3.14us) == U"3.14us");
	assert(U"{}"_fmt(42ns) == U"42ns");
	assert(U"{}"_fmt(3.14ns) == U"3.14ns");

	while (System::Update());
}
```
