### PR TITLE
JSON Iterator を C++20 イテレータに適応させる + α

### DIFF
--- a/Siv3D/include/Siv3D/JSON.hpp
+++ b/Siv3D/include/Siv3D/JSON.hpp
@@ -57,7 +57,7 @@ namespace s3d
 		JSONIterator(const JSONIterator&);
 
 		SIV3D_NODISCARD_CXX20
-		explicit JSONIterator(const detail::JSONIteratorDetail&);
+		explicit JSONIterator(JSON* parent, difference_type index, const detail::JSONIteratorDetail&);
 
 		JSONIterator& operator =(const JSONIterator& rhs);
 
@@ -89,6 +89,10 @@ namespace s3d
 
 	private:
 
+		JSON* m_parent = nullptr;
+
+		difference_type m_index = -1;
+
 		std::shared_ptr<detail::JSONIteratorDetail> m_detail;
 	};
 
@@ -112,7 +116,7 @@ namespace s3d
 		JSONConstIterator(const JSONConstIterator&);
 
 		SIV3D_NODISCARD_CXX20
-		explicit JSONConstIterator(const detail::JSONConstIteratorDetail&);
+		explicit JSONConstIterator(const JSON* parent, difference_type index, const detail::JSONConstIteratorDetail&);
 
 		JSONConstIterator& operator =(const JSONIterator& rhs);
 
@@ -145,6 +149,10 @@ namespace s3d
 		bool operator !=(const JSONConstIterator& other) const noexcept;
 
 	private:
+
+		const JSON* m_parent = nullptr;
+
+		difference_type m_index = -1;
 
 		std::shared_ptr<detail::JSONConstIteratorDetail> m_detail;
 	};

--- a/Siv3D/include/Siv3D/JSON.hpp
+++ b/Siv3D/include/Siv3D/JSON.hpp
@@ -42,6 +42,14 @@ namespace s3d
 	{
 	public:
 
+		friend JSONConstIterator;
+
+		using value_type = JSONItem;
+
+		using difference_type = ptrdiff_t;
+
+		using iterator_concept = std::bidirectional_iterator_tag;
+
 		SIV3D_NODISCARD_CXX20
 		JSONIterator() = default;
 
@@ -57,8 +65,12 @@ namespace s3d
 
 		JSONIterator operator ++(int);
 
+		JSONIterator& operator --();
+
+		JSONIterator operator --(int);
+
 		[[nodiscard]]
-		JSONIterator operator +(size_t index) const;
+		JSONIterator operator +(difference_type index) const;
 
 		[[nodiscard]]
 		JSONItem operator *() const;
@@ -84,8 +96,17 @@ namespace s3d
 	{
 	public:
 
+		using value_type = const JSONItem;
+
+		using difference_type = ptrdiff_t;
+
+		using iterator_concept = std::bidirectional_iterator_tag;
+
 		SIV3D_NODISCARD_CXX20
 		JSONConstIterator() = default;
+
+		SIV3D_NODISCARD_CXX20
+		JSONConstIterator(const JSONIterator&);
 
 		SIV3D_NODISCARD_CXX20
 		JSONConstIterator(const JSONConstIterator&);
@@ -93,14 +114,20 @@ namespace s3d
 		SIV3D_NODISCARD_CXX20
 		explicit JSONConstIterator(const detail::JSONConstIteratorDetail&);
 
+		JSONConstIterator& operator =(const JSONIterator& rhs);
+
 		JSONConstIterator& operator =(const JSONConstIterator& rhs);
 
 		JSONConstIterator& operator ++();
 
 		JSONConstIterator operator ++(int);
 
+		JSONConstIterator& operator --();
+
+		JSONConstIterator operator --(int);
+
 		[[nodiscard]]
-		JSONConstIterator operator +(size_t index) const;
+		JSONConstIterator operator +(difference_type index) const;
 
 		[[nodiscard]]
 		const JSONItem operator *() const;
@@ -126,8 +153,14 @@ namespace s3d
 	{
 	public:
 
+		using value_type = JSON;
+
+		using difference_type = ptrdiff_t;
+
+		using iterator_concept = std::input_iterator_tag;
+
 		SIV3D_NODISCARD_CXX20
-		JSONIterationProxy() = default;
+		JSONIterationProxy() = delete;
 
 		SIV3D_NODISCARD_CXX20
 		JSONIterationProxy(const JSONIterationProxy&);

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -103,15 +103,21 @@ namespace s3d
 	//////////////////////////////////////////////////
 
 	JSONIterator::JSONIterator(const JSONIterator& rhs)
-		: m_detail{ std::make_shared<detail::JSONIteratorDetail>(*rhs.m_detail) } {}
+		: m_parent{ rhs.m_parent }
+		, m_index{ rhs.m_index }
+		, m_detail{ std::make_shared<detail::JSONIteratorDetail>(*rhs.m_detail) } {}
 
-	JSONIterator::JSONIterator(const detail::JSONIteratorDetail& d)
-		: m_detail{ std::make_shared<detail::JSONIteratorDetail>(d.it) } {}
+	JSONIterator::JSONIterator(JSON* parent, JSONIterator::difference_type index, const detail::JSONIteratorDetail& d)
+		: m_parent{ parent }
+		, m_index{ index }
+		, m_detail{ std::make_shared<detail::JSONIteratorDetail>(d.it) } {}
 
 	JSONIterator& JSONIterator::operator =(const JSONIterator& rhs)
 	{
 		JSONIterator tmp{ rhs };
 
+		this->m_parent = tmp.m_parent;
+		this->m_index  = tmp.m_index;
 		this->m_detail = std::move(tmp.m_detail);
 
 		return *this;
@@ -120,6 +126,8 @@ namespace s3d
 	JSONIterator& JSONIterator::operator ++()
 	{
 		++m_detail->it;
+
+		++m_index;
 
 		return *this;
 	}
@@ -137,6 +145,8 @@ namespace s3d
 	{
 		--m_detail->it;
 
+		--m_index;
+
 		return *this;
 	}
 
@@ -153,7 +163,7 @@ namespace s3d
 	{
 		const detail::JSONIteratorDetail tmp{ m_detail->it + index };
 
-		return JSONIterator{ tmp };
+		return JSONIterator{ m_parent, m_index + index, tmp };
 	}
 
 	JSONItem JSONIterator::operator *() const
@@ -163,7 +173,24 @@ namespace s3d
 
 	String JSONIterator::key() const
 	{
-		return Unicode::FromUTF8(m_detail->it.key());
+		if (m_parent != nullptr)
+			SIV3D_LIKELY
+			{
+				switch (m_parent->getType())
+				{
+				case JSONValueType::Object:
+					return Unicode::FromUTF8(m_detail->it.key());
+				case JSONValueType::Array:
+					return Format(m_index);
+				default:
+					return U"";
+				}
+			}
+		else
+			SIV3D_UNLIKELY
+			{
+				throw Error{ U"This JSONIterator has not been constructed from any JSON." };
+			}
 	}
 
 	JSON JSONIterator::value() const
@@ -192,13 +219,19 @@ namespace s3d
 	//////////////////////////////////////////////////
 
 	JSONConstIterator::JSONConstIterator(const JSONIterator& rhs)
-		: m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(*rhs.m_detail) } {}
+		: m_parent{ rhs.m_parent }
+		, m_index{ rhs.m_index }
+		, m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(*rhs.m_detail) } {}
 
 	JSONConstIterator::JSONConstIterator(const JSONConstIterator& rhs)
-		: m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(*rhs.m_detail) } {}
+		: m_parent{ rhs.m_parent }
+		, m_index{ rhs.m_index }
+		, m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(*rhs.m_detail) } {}
 
-	JSONConstIterator::JSONConstIterator(const detail::JSONConstIteratorDetail& d)
-		: m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(d.it) } {}
+	JSONConstIterator::JSONConstIterator(const JSON* parent, JSONConstIterator::difference_type index, const detail::JSONConstIteratorDetail& d)
+		: m_parent{ parent }
+		, m_index{ index }
+		, m_detail{ std::make_shared<detail::JSONConstIteratorDetail>(d.it) } {}
 
 	JSONConstIterator& JSONConstIterator::operator =(const JSONIterator& rhs)
 	{
@@ -213,6 +246,8 @@ namespace s3d
 	{
 		JSONConstIterator tmp{ rhs };
 
+		this->m_parent = tmp.m_parent;
+		this->m_index  = tmp.m_index;
 		this->m_detail = std::move(tmp.m_detail);
 
 		return *this;
@@ -221,6 +256,8 @@ namespace s3d
 	JSONConstIterator& JSONConstIterator::operator ++()
 	{
 		++m_detail->it;
+
+		++m_index;
 
 		return *this;
 	}
@@ -238,6 +275,8 @@ namespace s3d
 	{
 		--m_detail->it;
 
+		--m_index;
+
 		return *this;
 	}
 
@@ -254,7 +293,7 @@ namespace s3d
 	{
 		const detail::JSONConstIteratorDetail tmp{ m_detail->it + index };
 
-		return JSONConstIterator{ tmp };
+		return JSONConstIterator{ m_parent, m_index + index, tmp };
 	}
 
 	const JSONItem JSONConstIterator::operator *() const
@@ -264,7 +303,24 @@ namespace s3d
 
 	String JSONConstIterator::key() const
 	{
-		return Unicode::FromUTF8(m_detail->it.key());
+		if (m_parent != nullptr)
+			SIV3D_LIKELY
+			{
+				switch (m_parent->getType())
+				{
+				case JSONValueType::Object:
+					return Unicode::FromUTF8(m_detail->it.key());
+				case JSONValueType::Array:
+					return Format(m_index);
+				default:
+					return U"";
+				}
+			}
+		else
+			SIV3D_UNLIKELY
+			{
+				throw Error{ U"This JSONConstIterator has not been constructed from any JSON." };
+			}
 	}
 
 	const JSON JSONConstIterator::value() const
@@ -870,22 +926,22 @@ namespace s3d
 
 	JSON::iterator JSON::begin()
 	{
-		return iterator{ detail::JSONIteratorDetail(m_detail->get().begin()) };
+		return iterator{ std::addressof(*this), 0, detail::JSONIteratorDetail(m_detail->get().begin()) };
 	}
 
 	JSON::const_iterator JSON::begin() const
 	{
-		return const_iterator{ detail::JSONConstIteratorDetail(m_detail->get().begin()) };
+		return const_iterator{ std::addressof(*this), 0, detail::JSONConstIteratorDetail(m_detail->get().begin()) };
 	}
 
 	JSON::iterator JSON::end()
 	{
-		return iterator{ detail::JSONIteratorDetail(m_detail->get().end()) };
+		return iterator{ std::addressof(*this), static_cast<JSON::iterator::difference_type>(size()), detail::JSONIteratorDetail(m_detail->get().end()) };
 	}
 
 	JSON::const_iterator JSON::end() const
 	{
-		return const_iterator{ detail::JSONConstIteratorDetail(m_detail->get().end()) };
+		return const_iterator{ std::addressof(*this), static_cast<JSON::iterator::difference_type>(size()), detail::JSONConstIteratorDetail(m_detail->get().end()) };
 	}
 
 	JSONArrayView JSON::arrayView() const

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -237,7 +237,9 @@ namespace s3d
 	{
 		JSONConstIterator tmp{ rhs };
 
-		std::ranges::swap(*this, tmp);
+		this->m_parent = tmp.m_parent;
+		this->m_index  = tmp.m_index;
+		this->m_detail = std::move(tmp.m_detail);
 
 		return *this;
 	}


### PR DESCRIPTION
JSON Iterator について、次の変更を加えました。
- `value_type`, `difference_type`, `iterator_concept` を定義
- 双方向イテレータに対応（デクリメント実装）
-  `JSONConstIterator` を `JSONIterator` から構築可能に
- `object`以外の要素も`key`を取得しながら走査出来るように
  - メンバ `m_parent`, `m_index` を追加
  - `arrray` な要素の `key` は `m_index` から補完
  - `object` でも `array` でもない場合の `key` は空文字列

`JSONIterationProxy` の方は、今回のイテレータ対応で恐らく存在意義を失うので、あまり変更は加えていません。一応、現状入力イテレータであるということ、nlohmann-jsonの方でもデフォルトコンストラクタが無い、この2点に合わせてデフォルト構築を削除しました。

ユーザーコード側での変更点は、通常のイテレータですべての要素を走査出来るようになったため、あえて`arrayView`を使う必要がなくなった点かと思います。
```cpp
#include <Siv3D.hpp> // OpenSiv3D v0.6.6
#include <ranges>

void Main()
{
	static_assert(std::bidirectional_iterator<JSON::iterator>);
	static_assert(std::bidirectional_iterator<JSON::const_iterator>);
	static_assert(std::input_iterator<JSONIterationProxy>);

	JSON json = JSON::Parse(UR"({"key":[5,6,7,8,9]})");

	Console << U"object に対して";
	for (auto&& [key, value] : json)
	{
		Console << U"key: '{}', value: '{}'"_fmt(key, value.format());
	}
	Console << U"";

	Console << U"array に対して";
	for (auto&& [key, value] : json[U"key"])
	{
		Console << U"key: '{}', value: '{}'"_fmt(key, value.format());
	}
	Console << U"";

	Console << U"その他の値に対して";
	for (auto&& [key, value] : json[U"key"][0])
	{
		Console << U"key: '{}', value: '{}'"_fmt(key, value.format());
	}
	Console << U"";

	// const iterator は 通常 iterator から構築可能に
	std::ranges::iterator_t<JSON>       i1 = std::ranges::begin(json);
	std::ranges::iterator_t<const JSON> i2 = std::ranges::begin(json);
	std::ranges::iterator_t<const JSON> i3 = std::ranges::cbegin(json);

	Console << U"その流れで Ranges Library も使用可能に";
	for (auto&& [key, value] : json[U"key"]
	                               | std::views::reverse
	                               | std::views::filter([](auto j) { return j.value.get<int>() <= 7; }))
	{
		Console << U"key: '{}', value: '{}'"_fmt(key, value.format());
	}
	Console << U"";

	while (System::Update())
	{
	}
}

```

```
object に対して
key: 'key', value: '[
  5,
  6,
  7,
  8,
  9
]'

array に対して
key: '0', value: '5'
key: '1', value: '6'
key: '2', value: '7'
key: '3', value: '8'
key: '4', value: '9'

その他の値に対して
key: '', value: '5'

その流れで Ranges Library も使用可能に
key: '2', value: '7'
key: '1', value: '6'
key: '0', value: '5'
```