### PR TITLE
Optional<T>の代入演算子を使用すると意図せず中身がムーブされる不具合を修正

### DIFF
--- a/Siv3D/include/Siv3D/Optional.hpp
+++ b/Siv3D/include/Siv3D/Optional.hpp
@@ -64,7 +64,10 @@ namespace s3d
 		
 		constexpr Optional& operator =(Optional&& other) noexcept(std::is_nothrow_move_assignable_v<Type> && std::is_nothrow_move_constructible_v<Type>);
 
-		template <class U = Type>
+		template <class U = Type, std::enable_if_t<std::disjunction_v<
+			std::is_assignable<std::optional<Type>&, U>,
+			std::is_assignable<std::optional<Type>&, const U&>,
+			std::is_assignable<std::optional<Type>&, U&&>>>* = nullptr>
 		Optional& operator =(U&& value);
 
 		template <class U>

--- a/Siv3D/include/Siv3D/detail/Optional.ipp
+++ b/Siv3D/include/Siv3D/detail/Optional.ipp
@@ -55,10 +55,13 @@ namespace s3d
 	}
 
 	template <class Type>
-	template <class U>
+	template <class U, std::enable_if_t<std::disjunction_v<
+		std::is_assignable<std::optional<Type>&, U>,
+		std::is_assignable<std::optional<Type>&, const U&>,
+		std::is_assignable<std::optional<Type>&, U&&>>>*>
 	inline Optional<Type>& Optional<Type>::operator =(U&& value)
 	{
-		base_type::operator =(std::move(value));
+		base_type::operator =(std::forward<U>(value));
 		return *this;
 	}
 


### PR DESCRIPTION
`Optional<T>`でコピー代入しようとすると意図せず中身がムーブされる不具合があったので修正しました。

## 再現コード

`a`から`b`へのコピー代入を意図して下記のコードを書くと、コピー元の`a`のStringの中身が空になる現象が発生します。

```cpp
void Main()
{
	Optional<String> a = U"test";
	Optional<String> b;

	b = a;

	Print << U"a:" << a.value_or(U"none");
	Print << U"b:" << b.value_or(U"none");

	while (System::Update()) {}
}
```
![image](https://user-images.githubusercontent.com/14288724/211363480-b99b7f6b-3243-4daa-be63-79746d6bd34e.png)

## 修正内容

下記2点を修正。

- `Optional<T>::operator =(U&&)`のテンプレートパラメータ`U`がforwarding referenceなのに`std::move`で右辺値参照へキャストされていたため、意図しないムーブが発生していた
    - `std::move`→`std::forward`へ修正
- `Optional<T>`を代入した場合に、定義されているコピー代入・ムーブ代入が呼ばれず、代わりにforwarding referenceを受け取る`Optional<T>::operator =(U&&)`の方が呼ばれていた
    - forwarding referenceの方は`U`が`std::optional<T>`へ代入可能な場合のみ呼ばれるよう、SFINAEの条件を足すことで修正

## 本修正による副次的な効果

これまでエラーになっていた下記のコードが、std::optionalと同じようにコンパイルが通るようになります。

```cpp
Optional<int32> a = 3;
Optional<double> b = 2.0;
b = a;
```

ただし、下記のコンパイルは依然通りません(※std::optionalの場合は通る)。

```cpp
Optional<Optional<int32>> a = 3;
Optional<Optional<double>> b = 2.0;
b = a;
```

## テストコード

下記のコードで、失敗していた3つのケースが正常動作するようになったことを確認しました。
https://gist.github.com/m4saka/7c71d81eadb675afb9e2de36c871e2a1
![image](https://user-images.githubusercontent.com/14288724/211627922-8b61ce41-5b92-4818-9a2f-7f57dd839fa2.png)