### PR TITLE
Optional<Optional<T>>へOptional<T>{none}を代入した時の挙動がstd::optionalと異なるのを修正

### DIFF
--- a/Siv3D/include/Siv3D/detail/Optional.ipp
+++ b/Siv3D/include/Siv3D/detail/Optional.ipp
@@ -72,7 +72,14 @@ namespace s3d
 		}
 		else
 		{
-			reset();
+			if constexpr (std::is_assignable_v<Type&, const Optional<U>&>)
+			{
+				base_type::operator =(other);
+			}
+			else
+			{
+				reset();
+			}
 		}
 
 		return *this;
@@ -88,7 +95,14 @@ namespace s3d
 		}
 		else
 		{
-			reset();
+			if constexpr (std::is_assignable_v<Type&, Optional<U>&&>)
+			{
+				base_type::operator =(std::move(other));
+			}
+			else
+			{
+				reset();
+			}
 		}
 
 		return *this;


### PR DESCRIPTION
`Optional<Optional<T>>`型の変数へ`Optional<T>{none}`を代入した時、本来は「外側のOptionalは値あり、内側のOptionalは値なし」となるべきところが、「外側のOptionalが値なし」となってしまっていたのを修正しました。

## 再現コード

下記の`a`と`b`はそれぞれコンストラクタと代入演算子で同じ値を与えているにもかかわらず、挙動が異なっていることが確認できます。
※Optionalではなくstd::optionalを使用した場合は両方trueが得られる

```cpp
Optional<Optional<String>> a = Optional<String>{ none };

Optional<Optional<String>> b;
b = Optional<String>{ none };

Print << U"a.has_value(): " << a.has_value();
Print << U"b.has_value(): " << b.has_value();
```
![image](https://user-images.githubusercontent.com/14288724/211638415-bc5f1c2a-564f-4237-8499-73f927f46024.png)

## 原因

`Optional<Optional<U>>`には`Optional<U>`を中身の値として代入すべきところを、`reset`が呼ばれていることで、外側のOptionalの値がリセットされていたため。

## 修正内容

コピー代入演算子、ムーブ代入演算子のそれぞれについて下記を修正。

- `Type`へ`Optional<U>`が代入可能な場合、`reset`は呼ばずに`Optional<U>`型のまま代入するように修正
    - これにより、`Optional<Optional<U>>`型変数へ `Optional<U>`型や`Optional<U>`型と互換性のある型の値を代入しようとしたとき、`Optional<U>`が中身の値として代入されるようになった

## テストコード

下記のコードで、失敗していたC6～C8のケースが正常動作するようになったことを確認しました。
※同時に出している #938 の不具合修正およびテストコードを含めた状態でテストしています
https://gist.github.com/m4saka/623ae9608a4b50ada7ff41ddd7c0ff21

![image](https://user-images.githubusercontent.com/14288724/211654600-5e8411f1-d4fc-4d70-b6f0-4a4f81777cce.png)