### PR TITLE
デューティー比を指定可能な矩形波 Pulse0_1, Pulse1_1 を追加 #966

### DIFF
--- a/Siv3D/include/Siv3D/Periodic.hpp
+++ b/Siv3D/include/Siv3D/Periodic.hpp
@@ -150,6 +150,22 @@ namespace s3d
 		[[nodiscard]]
 		double Square0_1(const Duration& period, double t = Scene::Time()) noexcept;
 
+		/// @brief 矩形波に従って、周期的に [0.0, 1.0] の値を返します。
+		/// @param periodSec 周期（秒）
+		/// @param dutyCycle デューティー比、周期内で波形の大きさが 1.0 である時間の割合
+		/// @param t 経過時間（秒）
+		/// @return 0.0 または 1.0
+		[[nodiscard]]
+		double Pulse0_1(double periodSec, double dutyCycle, double t = Scene::Time()) noexcept;
+
+		/// @brief 矩形波に従って、周期的に [0.0, 1.0] の値を返します。
+		/// @param periodSec 周期（秒）
+		/// @param dutyCycle デューティー比、周期内で波形の大きさが 1.0 である時間の割合
+		/// @param t 経過時間（秒）
+		/// @return 0.0 または 1.0
+		[[nodiscard]]
+		double Pulse0_1(const Duration& period, double dutyCycle, double t = Scene::Time()) noexcept;
+
 		/// @brief 三角波に従って、周期的に [0.0, 1.0] の値を返します。
 		/// @param periodSec 周期（秒）
 		/// @param t 経過時間（秒）
@@ -220,6 +236,22 @@ namespace s3d
 		/// @return [-1.0, 1.0] の範囲の値
 		[[nodiscard]]
 		double Square1_1(const Duration& period, double t = Scene::Time()) noexcept;
+
+		/// @brief 矩形波に従って、周期的に [-1.0, 1.0] の値を返します。
+		/// @param periodSec 周期（秒）
+		/// @param dutyCycle デューティー比、周期内で波形の大きさが 1.0 である時間の割合
+		/// @param t 経過時間（秒）
+		/// @return -1.0 または 1.0
+		[[nodiscard]]
+		double Pulse1_1(double periodSec, double dutyCycle, double t = Scene::Time()) noexcept;
+
+		/// @brief 矩形波に従って、周期的に [-1.0, 1.0] の値を返します。
+		/// @param periodSec 周期（秒）
+		/// @param dutyCycle デューティー比、周期内で波形の大きさが 1.0 である時間の割合
+		/// @param t 経過時間（秒）
+		/// @return -1.0 または 1.0
+		[[nodiscard]]
+		double Pulse1_1(const Duration& period, double dutyCycle, double t = Scene::Time()) noexcept;
 
 		/// @brief 三角波に従って、周期的に [-1.0, 1.0] の値を返します。
 		/// @param periodSec 周期（秒）

--- a/Siv3D/src/Siv3D/Periodic/SivPeriodic.cpp
+++ b/Siv3D/src/Siv3D/Periodic/SivPeriodic.cpp
@@ -37,6 +37,16 @@ namespace s3d
 			return Square0_1(period.count(), t);
 		}
 
+		double Pulse0_1(double periodSec, double dutyCycle, const double t) noexcept
+		{
+			return (std::fmod(t, periodSec) < (periodSec * dutyCycle)) ? 1.0 : 0.0;
+		}
+
+		double Pulse0_1(const Duration& period, double dutyCycle, const double t) noexcept
+		{
+			return Pulse0_1(period.count(), dutyCycle, t);
+		}
+
 		double Triangle0_1(const double periodSec, const double t) noexcept
 		{
 			const double x = (std::fmod(t, periodSec) / (periodSec * 0.5));
@@ -104,6 +114,16 @@ namespace s3d
 		double Square1_1(const Duration& period, const double t) noexcept
 		{
 			return Square1_1(period.count(), t);
+		}
+
+		double Pulse1_1(const double periodSec, double dutyCycle, const double t) noexcept
+		{
+			return (std::fmod(t, periodSec) < (periodSec * dutyCycle)) ? 1.0 : -1.0;
+		}
+
+		double Pulse1_1(const Duration& period, double dutyCycle, const double t) noexcept
+		{
+			return Pulse1_1(period.count(), dutyCycle, t);
 		}
 
 		double Triangle1_1(const double periodSec, const double t) noexcept


### PR DESCRIPTION
Periodic名前空間の関数として、デューティー比を指定できる矩形波

- `Pulse0_1`
- `Pulse1_1`

を追加しました。