### PR TITLE
フォントのフォールバックの際に表示する文字のインデックスがずれる問題を修正

### DIFF
--- a/Siv3D/src/Siv3D/Font/FontData.cpp
+++ b/Siv3D/src/Siv3D/Font/FontData.cpp
@@ -176,6 +176,8 @@ namespace s3d
 					}
 				}
 
+				const size_t fallbackStrSize = ((count <= (i + k)) ? s.size() : glyphInfo.info[(i + k)].cluster) - pos;
+
 				bool fallbackDone = false;
 				uint32 fallbackIndex = 1;
 
@@ -187,7 +189,7 @@ namespace s3d
 					}
 
 					const Array<GlyphCluster> clustersB = 
-						SIV3D_ENGINE(Font)->getGlyphClusters(fallbackFont.lock()->id(), s.substr(i, k), false, ligature);
+						SIV3D_ENGINE(Font)->getGlyphClusters(fallbackFont.lock()->id(), s.substr(pos, fallbackStrSize), false, ligature);
 
 					if (clustersB.none([](const GlyphCluster& g) { return (g.glyphIndex == 0); }))
 					{


### PR DESCRIPTION
フォントのフォールバックの際に、リガチャや異体字セレクタなどにより発生する `StringView` のインデックスと実際に表示する文字列のインデックスのずれが考慮されず、ずれたインデックスの文字を表示していた問題 (#971) を修正しました。
