### PR TITLE
Array::fetch の未定義動作を修正

### DIFF
--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -614,7 +614,7 @@ namespace s3d
 		/// @param defaultValue インデックスが範囲外の場合に返すデフォルト値
 		/// @return 指定したインデックスにある要素、範囲外の場合 defaultValue
 		[[nodiscard]]
-		const value_type& fetch(size_t index, const value_type& defaultValue) const;
+		value_type fetch(size_t index, const value_type& defaultValue) const;
 
 		/// @brief 指定した値を全ての要素に代入します。
 		/// @param value 代入する値

--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -613,8 +613,9 @@ namespace s3d
 		/// @param index インデックス
 		/// @param defaultValue インデックスが範囲外の場合に返すデフォルト値
 		/// @return 指定したインデックスにある要素、範囲外の場合 defaultValue
+		template <class U>
 		[[nodiscard]]
-		value_type fetch(size_t index, const value_type& defaultValue) const;
+		value_type fetch(size_t index, U&& defaultValue) const;
 
 		/// @brief 指定した値を全ての要素に代入します。
 		/// @param value 代入する値

--- a/Siv3D/include/Siv3D/Grid.hpp
+++ b/Siv3D/include/Siv3D/Grid.hpp
@@ -366,11 +366,13 @@ namespace s3d
 		template <class Fty, std::enable_if_t<std::is_invocable_v<Fty, Point, Type>>* = nullptr>
 		const Grid& each_index(Fty f) const;
 
+		template <class U>
 		[[nodiscard]]
-		value_type fetch(size_type y, size_type x, const value_type& defaultValue) const;
+		value_type fetch(size_type y, size_type x, U&& defaultValue) const;
 
+		template <class U>
 		[[nodiscard]]
-		value_type fetch(Point pos, const value_type& defaultValue) const;
+		value_type fetch(Point pos, U&& defaultValue) const;
 
 		Grid& fill(const value_type& value);
 

--- a/Siv3D/include/Siv3D/Grid.hpp
+++ b/Siv3D/include/Siv3D/Grid.hpp
@@ -367,10 +367,10 @@ namespace s3d
 		const Grid& each_index(Fty f) const;
 
 		[[nodiscard]]
-		const value_type& fetch(size_type y, size_type x, const value_type& defaultValue) const;
+		value_type fetch(size_type y, size_type x, const value_type& defaultValue) const;
 
 		[[nodiscard]]
-		const value_type& fetch(Point pos, const value_type& defaultValue) const;
+		value_type fetch(Point pos, const value_type& defaultValue) const;
 
 		Grid& fill(const value_type& value);
 

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -713,7 +713,7 @@ namespace s3d
 	}
 
 	template <class Type, class Allocator>
-	inline const typename Array<Type, Allocator>::value_type& Array<Type, Allocator>::fetch(const size_t index, const value_type& defaultValue) const
+	inline typename Array<Type, Allocator>::value_type Array<Type, Allocator>::fetch(const size_t index, const value_type& defaultValue) const
 	{
 		if (index >= size())
 		{

--- a/Siv3D/include/Siv3D/detail/Array.ipp
+++ b/Siv3D/include/Siv3D/detail/Array.ipp
@@ -713,11 +713,12 @@ namespace s3d
 	}
 
 	template <class Type, class Allocator>
-	inline typename Array<Type, Allocator>::value_type Array<Type, Allocator>::fetch(const size_t index, const value_type& defaultValue) const
+	template <class U>
+	inline typename Array<Type, Allocator>::value_type Array<Type, Allocator>::fetch(const size_t index, U&& defaultValue) const
 	{
 		if (index >= size())
 		{
-			return defaultValue;
+			return std::forward<U>(defaultValue);
 		}
 
 		return operator[](index);

--- a/Siv3D/include/Siv3D/detail/BoolArray.ipp
+++ b/Siv3D/include/Siv3D/detail/BoolArray.ipp
@@ -393,7 +393,7 @@ namespace s3d
 		}
 
 		[[nodiscard]]
-		const value_type& fetch(size_t index, const value_type& defaultValue) const
+		value_type fetch(size_t index, const value_type& defaultValue) const
 		{
 			if (index >= size())
 			{

--- a/Siv3D/include/Siv3D/detail/BoolArray.ipp
+++ b/Siv3D/include/Siv3D/detail/BoolArray.ipp
@@ -392,12 +392,13 @@ namespace s3d
 			return *this;
 		}
 
+		template <class U>
 		[[nodiscard]]
-		value_type fetch(size_t index, const value_type& defaultValue) const
+		value_type fetch(size_t index, U&& defaultValue) const
 		{
 			if (index >= size())
 			{
-				return defaultValue;
+				return std::forward<U>(defaultValue);
 			}
 
 			return operator[](index);

--- a/Siv3D/include/Siv3D/detail/Grid.ipp
+++ b/Siv3D/include/Siv3D/detail/Grid.ipp
@@ -927,20 +927,22 @@ namespace s3d
 	}
 
 	template <class Type, class Allocator>
-	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const size_type y, const size_type x, const value_type& defaultValue) const
+	template <class U>
+	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const size_type y, const size_type x, U&& defaultValue) const
 	{
 		if (not inBounds(y, x))
 		{
-			return defaultValue;
+			return std::forward<U>(defaultValue);
 		}
 
 		return m_data[y * m_width + x];
 	}
 
 	template <class Type, class Allocator>
-	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const Point pos, const value_type& defaultValue) const
+	template <class U>
+	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const Point pos, U&& defaultValue) const
 	{
-		return fetch(pos.y, pos.x, defaultValue);
+		return fetch(pos.y, pos.x, std::forward<U>(defaultValue));
 	}
 
 	template <class Type, class Allocator>

--- a/Siv3D/include/Siv3D/detail/Grid.ipp
+++ b/Siv3D/include/Siv3D/detail/Grid.ipp
@@ -927,7 +927,7 @@ namespace s3d
 	}
 
 	template <class Type, class Allocator>
-	inline const typename Grid<Type, Allocator>::value_type& Grid<Type, Allocator>::fetch(const size_type y, const size_type x, const value_type& defaultValue) const
+	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const size_type y, const size_type x, const value_type& defaultValue) const
 	{
 		if (not inBounds(y, x))
 		{
@@ -938,7 +938,7 @@ namespace s3d
 	}
 
 	template <class Type, class Allocator>
-	inline const typename Grid<Type, Allocator>::value_type& Grid<Type, Allocator>::fetch(const Point pos, const value_type& defaultValue) const
+	inline typename Grid<Type, Allocator>::value_type Grid<Type, Allocator>::fetch(const Point pos, const value_type& defaultValue) const
 	{
 		return fetch(pos.y, pos.x, defaultValue);
 	}


### PR DESCRIPTION
Array::fetch の返り値が参照であるため、`defaultValue`が pvalue への参照である場合にダングリング参照を発生させ、未定義動作を起こしていました。返り値の型を参照から値へと変更し、未定義動作を回避するようにしました。

参照: https://discord.com/channels/443310697397354506/443310697397354508/1092358956443254794