### PR TITLE
SimpleTable::DefaultAlignmentのtypo修正

### DIFF
--- a/Siv3D/include/Siv3D/SimpleTable.hpp
+++ b/Siv3D/include/Siv3D/SimpleTable.hpp
@@ -352,7 +352,7 @@ namespace s3d
 
 	private:
 
-		static constexpr int32 DefaultAlignmnet = -1;
+		static constexpr int32 DefaultAlignment = -1;
 
 		Style m_style;
 

--- a/Siv3D/src/Siv3D/SimpleTable/SivSimpleTable.cpp
+++ b/Siv3D/src/Siv3D/SimpleTable/SivSimpleTable.cpp
@@ -93,7 +93,7 @@ namespace s3d
 
 	SimpleTable& SimpleTable::push_back_row(const Array<String>& texts)
 	{
-		Array<int32> textAlignments(m_grid.width(), DefaultAlignmnet);
+		Array<int32> textAlignments(m_grid.width(), DefaultAlignment);
 
 		if (0 < m_grid.height())
 		{


### PR DESCRIPTION
`DefaultAlignment`のスペルに誤りがあったので修正しました。