### PR TITLE
SimpleGUI::TextBoxAt()でのHome、Endキーの動作を修正

### DIFF
--- a/Siv3D/src/Siv3D/SimpleGUI/SivSimpleGUI.cpp
+++ b/Siv3D/src/Siv3D/SimpleGUI/SivSimpleGUI.cpp
@@ -982,6 +982,21 @@ namespace s3d
 					text.cursorStopwatch.restart();
 				}
 
+				// [tab] キーで入力カーソルを非アクティブに
+				{
+					const String raw = TextInput::GetRawInput();
+					text.tabKey = raw.contains(U'\t');
+					text.enterKey = raw.contains(U'\r');
+
+					if (text.tabKey || text.enterKey)
+					{
+						text.active = false;
+					}
+				}
+			}
+
+			if (text.active && enabled && (not editingText))
+			{
 				// [home] キーでテキストカーソルを先頭へ移動
 				if (KeyHome.down())
 				{
@@ -994,18 +1009,6 @@ namespace s3d
 				{
 					text.cursorPos = text.text.length();
 					text.cursorStopwatch.restart();
-				}
-
-				// [tab] キーで入力カーソルを非アクティブに
-				{
-					const String raw = TextInput::GetRawInput();
-					text.tabKey = raw.contains(U'\t');
-					text.enterKey = raw.contains(U'\r');
-
-					if (text.tabKey || text.enterKey)
-					{
-						text.active = false;
-					}
 				}
 			}
 


### PR DESCRIPTION
SimpleGUI::TextBoxAt()で日本語入力中にHome、Endキーを押したときに、入力中の文字列の挿入位置が先頭、末尾に移動する不具合を修正しました