### PR TITLE
Font でタブの進みが 0 になるバグを修正

### DIFF
--- a/Siv3D/src/Siv3D/Font/GlyphCache/GlyphCacheCommon.cpp
+++ b/Siv3D/src/Siv3D/Font/GlyphCache/GlyphCacheCommon.cpp
@@ -16,7 +16,14 @@ namespace s3d
 	double GetTabAdvance(const double spaceWidth, const double scale, const double baseX, const double currentX, const int32 indentSize)
 	{
 		const double maxTabWidth = (spaceWidth * scale * indentSize);
-		const double newX = baseX + static_cast<int32>(((currentX + maxTabWidth) - baseX) / maxTabWidth) * maxTabWidth;
+		const int32 indentLevel = static_cast<int32>(((currentX + maxTabWidth) - baseX) / maxTabWidth);
+		double newX = (baseX + indentLevel * maxTabWidth);
+		// 戻り値が 0 になる場合は、浮動小数点数の誤差により indentLevel が 1 だけ小さく計算されている
+		if ((newX - currentX) == 0)
+		{
+			// indentLevel を 1 だけ増やして再計算
+			newX = (baseX + (indentLevel + 1) * maxTabWidth);
+		}
 		return (newX - currentX);
 	}
 


### PR DESCRIPTION
`Font` において、水平タブ (Horizontal Tabulation) の進みは `GetTabAdvance()` で計算されています。

https://github.com/Siv3D/OpenSiv3D/blob/a57edac1bbee31fd7cf95c5c17a9fe41f58d009f/Siv3D/src/Siv3D/Font/GlyphCache/GlyphCacheCommon.cpp?ts=4#L16-L21

文字列描画の基準点の $x$ 座標を `baseX` 、現在の文字描画の基準点の $x$ 座標を `currentX` 、最大タブ幅を `maxTabWidth` とします。
ここで、水平タブは $\\{$ `baseX` $+$ `maxTabWidth` $\\times n\\;|\\;n=1,2,\dots\\;\\}$ の `currentX` より大きい最小の要素で `currentX` を置き換えるというものです。
修正前の実装ではこの $n$ を `static_cast<int32>(((currentX + maxTabWidth) - baseX) / maxTabWidth)` によって求めています。
浮動小数点演算の誤差を $e\\;\\;(|e|\\ll1)$ とすると、 `static_cast<int32>(((currentX + maxTabWidth) - baseX) / maxTabWidth)` の結果は $\\lfloor(($ `currentX` $+$ `maxTabWidth` $) -$ `baseX` $) /$ `maxTabWidth` $+e\\rfloor$ となります。

簡単のため、`baseX` $=0$ である場合を考えます。
`currentX` $=$ `maxTabWidth` $\\times m\\;\\;(m=0,1,\dots)$ であるとき、 $n=m+1$ になることが期待されます。
しかし、 $e<0$ のとき $n=\\lfloor($ `maxTabWidth` $\\times m+$ `maxTabWidth` $) /$ `maxTabWidth` $+e\\rfloor=\\lfloor m+1+e\\rfloor=m$ であり、 $n$ が $1$ だけ小さくなります。
これが #1002 で報告したバグの原因となっていました。

このバグが発生したとき、 $n=m$ より、タブの進みは $0$ と計算されます。
そこで、このときを if 文で分岐し、 $n$ を $n+1$ で置換して計算しなおすことで、バグを修正しました。
