### PR TITLE
Font::renderPolygon で輪郭と穴が逆転するバグを修正

### DIFF
--- a/Siv3D/src/Siv3D/Font/GlyphRenderer/OutlineGlyphRenderer.cpp
+++ b/Siv3D/src/Siv3D/Font/GlyphRenderer/OutlineGlyphRenderer.cpp
@@ -156,6 +156,15 @@ namespace s3d
 				ring.unique_consecutive();
 			}
 
+			const auto orientation = FT_Outline_Get_Orientation(&face->glyph->outline);
+			if (orientation == FT_ORIENTATION_POSTSCRIPT)
+			{
+				for (auto& ring : userData.rings)
+				{
+					ring.reverse();
+				}
+			}
+
 			if (not closeRing)
 			{
 				for (auto& ring : userData.rings)


### PR DESCRIPTION
#1019 を修正しました。

![20230709-005838-286](https://github.com/Siv3D/OpenSiv3D/assets/61970673/5e525418-6776-400b-a0a3-c3201d4b3927)
