### PR TITLE
constexpr 文脈の非アクティブ共用体メンバの使用を修正

### DIFF
--- a/Siv3D/include/Siv3D/Ellipse.hpp
+++ b/Siv3D/include/Siv3D/Ellipse.hpp
@@ -134,16 +134,14 @@ namespace s3d
 		friend constexpr bool operator ==(const Ellipse& lhs, const Ellipse& rhs) noexcept
 		{
 			return (lhs.center == rhs.center)
-				&& (lhs.a == rhs.a)
-				&& (lhs.b == rhs.b);
+				&& (lhs.axes == rhs.axes);
 		}
 
 		[[nodiscard]]
 		friend constexpr bool operator !=(const Ellipse& lhs, const Ellipse& rhs) noexcept
 		{
 			return (lhs.center != rhs.center)
-				|| (lhs.a != rhs.a)
-				|| (lhs.b != rhs.b);
+				|| (lhs.axes != rhs.axes);
 		}
 
 		constexpr Ellipse& set(value_type _x, value_type _y, size_type _a, size_type _b) noexcept;

--- a/Siv3D/include/Siv3D/detail/Ellipse.ipp
+++ b/Siv3D/include/Siv3D/detail/Ellipse.ipp
@@ -55,7 +55,7 @@ namespace s3d
 
 	inline constexpr Ellipse::Ellipse(const RectF& rect) noexcept
 		: center{ rect.center() }
-		, axes{ (rect.w * 0.5), (rect.h * 0.5) } {}
+		, axes{ (rect.size.x * 0.5), (rect.size.y * 0.5) } {}
 
 	inline constexpr Ellipse& Ellipse::set(const value_type _x, const value_type _y, const size_type _a, const size_type _b) noexcept
 	{
@@ -96,7 +96,7 @@ namespace s3d
 
 	inline constexpr Ellipse& Ellipse::set(const RectF& rect) noexcept
 	{
-		return set(rect.center(), (rect.w * 0.5), (rect.h * 0.5));
+		return set(rect.center(), (rect.size.x * 0.5), (rect.size.y * 0.5));
 	}
 
 	inline constexpr Ellipse& Ellipse::set(const Ellipse& ellipse) noexcept
@@ -164,42 +164,42 @@ namespace s3d
 
 	inline constexpr Ellipse Ellipse::stretched(const value_type size) const noexcept
 	{
-		return{ center, (a + size), (b + size) };
+		return{ center, (axes.x + size), (axes.y + size) };
 	}
 
 	inline constexpr Ellipse Ellipse::stretched(const double _x, const double _y) const noexcept
 	{
-		return{ center, (a + _x), (b + _y) };
+		return{ center, (axes.x + _x), (axes.y + _y) };
 	}
 
 	inline constexpr Ellipse Ellipse::scaled(const double s) const noexcept
 	{
-		return{ center, (a * s), (b * s) };
+		return{ center, (axes.x * s), (axes.y * s) };
 	}
 
 	inline constexpr Ellipse Ellipse::scaled(const double sx, const double sy) const noexcept
 	{
-		return{ center, (a * sx), (b * sy) };
+		return{ center, (axes.x * sx), (axes.y * sy) };
 	}
 
 	inline constexpr Ellipse::position_type Ellipse::top() const noexcept
 	{
-		return{ x, (y - b) };
+		return{ center.x, (center.y - axes.y) };
 	}
 
 	inline constexpr Ellipse::position_type Ellipse::right() const noexcept
 	{
-		return{ (x + a), y };
+		return{ (center.x + axes.x), center.y };
 	}
 
 	inline constexpr Ellipse::position_type Ellipse::bottom() const noexcept
 	{
-		return{ x, (y + b) };
+		return{ center.x, (center.y + axes.y) };
 	}
 
 	inline constexpr Ellipse::position_type Ellipse::left() const noexcept
 	{
-		return{ (x - a), y };
+		return{ (center.x - axes.x), center.y };
 	}
 
 	inline constexpr Line Ellipse::horizontalDiameter() const noexcept
@@ -214,17 +214,17 @@ namespace s3d
 
 	inline constexpr Ellipse::value_type Ellipse::area() const noexcept
 	{
-		return (a * b * Math::Pi);
+		return (axes.x * axes.y * Math::Pi);
 	}
 
 	inline constexpr Circle Ellipse::boundingCircle() const noexcept
 	{
-		return{ center, Max(a, b) };
+		return{ center, Max(axes.x, axes.y) };
 	}
 
 	inline constexpr RectF Ellipse::boundingRect() const noexcept
 	{
-		return{ Arg::center = center, (a * 2), (b * 2) };
+		return{ Arg::center = center, (axes.x * 2), (axes.y * 2) };
 	}
 
 	inline constexpr Ellipse Ellipse::lerp(const Ellipse& other, const double f) const noexcept

--- a/Siv3D/include/Siv3D/detail/Geometry2D.ipp
+++ b/Siv3D/include/Siv3D/detail/Geometry2D.ipp
@@ -23,13 +23,13 @@ namespace s3d
 		[[nodiscard]]
 		inline constexpr std::tuple<double, double, double, double> GetLRTB(const Rect& rect) noexcept
 		{
-			return{ rect.x, (rect.x + rect.w), rect.y, (rect.y + rect.h) };
+			return{ rect.pos.x, (rect.pos.x + rect.size.x), rect.pos.y, (rect.pos.y + rect.size.y) };
 		}
 
 		[[nodiscard]]
 		inline constexpr std::tuple<double, double, double, double> GetLRTB(const RectF& rect) noexcept
 		{
-			return{ rect.x, (rect.x + rect.w), rect.y, (rect.y + rect.h) };
+			return{ rect.pos.x, (rect.pos.x + rect.size.x), rect.pos.y, (rect.pos.y + rect.size.y) };
 		}
 
 		[[nodiscard]]
@@ -118,18 +118,18 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Point& a, const Rect& b) noexcept
 		{
-			return (b.x <= a.x)
-				&& (a.x < (b.x + b.w))
-				&& (b.y <= a.y)
-				&& (a.y < (b.y + b.h));
+			return (b.pos.x <= a.x)
+				&& (a.x < (b.pos.x + b.size.x))
+				&& (b.pos.y <= a.y)
+				&& (a.y < (b.pos.y + b.size.y));
 		}
 
 		inline constexpr bool Intersect(const Point& a, const RectF& b) noexcept
 		{
-			return (b.x <= a.x)
-				&& (a.x < (b.x + b.w))
-				&& (b.y <= a.y)
-				&& (a.y < (b.y + b.h));
+			return (b.pos.x <= a.x)
+				&& (a.x < (b.pos.x + b.size.x))
+				&& (b.pos.y <= a.y)
+				&& (a.y < (b.pos.y + b.size.y));
 		}
 
 		inline constexpr bool Intersect(const Point& a, const Circle& b) noexcept
@@ -139,16 +139,16 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Point& a, const Ellipse& b) noexcept
 		{
-			if ((b.a == 0.0)
-				|| (b.b == 0.0))
+			if ((b.axes.x == 0.0)
+				|| (b.axes.y == 0.0))
 			{
 				return false;
 			}
 
-			const double xh = (b.x - a.x);
-			const double yk = (b.y - a.y);
+			const double xh = (b.center.x - a.x);
+			const double yk = (b.center.y - a.y);
 
-			return (((xh * xh) / (b.a * b.a) + (yk * yk) / (b.b * b.b)) <= 1.0);
+			return (((xh * xh) / (b.axes.x * b.axes.x) + (yk * yk) / (b.axes.y * b.axes.y)) <= 1.0);
 		}
 
 		inline constexpr bool Intersect(const Point& a, const Triangle& b) noexcept
@@ -203,14 +203,14 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Vec2& a, const Rect& b) noexcept
 		{
-			return (b.x <= a.x) && (a.x < (b.x + b.w))
-				&& (b.y <= a.y) && (a.y < (b.y + b.h));
+			return (b.pos.x <= a.x) && (a.x < (b.pos.x + b.size.x))
+				&& (b.pos.y <= a.y) && (a.y < (b.pos.y + b.size.y));
 		}
 
 		inline constexpr bool Intersect(const Vec2& a, const RectF& b) noexcept
 		{
-			return (b.x <= a.x) && (a.x < (b.x + b.w))
-				&& (b.y <= a.y) && (a.y < (b.y + b.h));
+			return (b.pos.x <= a.x) && (a.x < (b.pos.x + b.size.x))
+				&& (b.pos.y <= a.y) && (a.y < (b.pos.y + b.size.y));
 		}
 
 		inline constexpr bool Intersect(const Vec2& a, const Circle& b) noexcept
@@ -220,14 +220,14 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Vec2& a, const Ellipse& b) noexcept
 		{
-			if ((b.a == 0.0) || (b.b == 0.0))
+			if ((b.axes.x == 0.0) || (b.axes.y == 0.0))
 			{
 				return false;
 			}
 
-			const double xh = (b.x - a.x);
-			const double yk = (b.y - a.y);
-			return (((xh * xh) / (b.a * b.a) + (yk * yk) / (b.b * b.b)) <= 1.0);
+			const double xh = (b.center.x - a.x);
+			const double yk = (b.center.y - a.y);
+			return (((xh * xh) / (b.axes.x * b.axes.x) + (yk * yk) / (b.axes.y * b.axes.y)) <= 1.0);
 		}
 
 		inline constexpr bool Intersect(const Vec2& a, const Triangle& b) noexcept
@@ -296,18 +296,18 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Rect& a, const Rect& b) noexcept
 		{
-			return (a.x < (b.x + b.w))
-				&& (b.x < (a.x + a.w))
-				&& (a.y < (b.y + b.h))
-				&& (b.y < (a.y + a.h));
+			return (a.pos.x < (b.pos.x + b.size.x))
+				&& (b.pos.x < (a.pos.x + a.size.x))
+				&& (a.pos.y < (b.pos.y + b.size.y))
+				&& (b.pos.y < (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Intersect(const Rect& a, const RectF& b) noexcept
 		{
-			return (a.x < (b.x + b.w))
-				&& (b.x < (a.x + a.w))
-				&& (a.y < (b.y + b.h))
-				&& (b.y < (a.y + a.h));
+			return (a.pos.x < (b.pos.x + b.size.x))
+				&& (b.pos.x < (a.pos.x + a.size.x))
+				&& (a.pos.y < (b.pos.y + b.size.y))
+				&& (b.pos.y < (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Intersect(const RectF& a, const Point& b) noexcept
@@ -337,10 +337,10 @@ namespace s3d
 
 		inline constexpr bool Intersect(const RectF& a, const RectF& b) noexcept
 		{
-			return (a.x < (b.x + b.w))
-				&& (b.x < (a.x + a.w))
-				&& (a.y < (b.y + b.h))
-				&& (b.y < (a.y + a.h));
+			return (a.pos.x < (b.pos.x + b.size.x))
+				&& (b.pos.x < (a.pos.x + a.size.x))
+				&& (a.pos.y < (b.pos.y + b.size.y))
+				&& (b.pos.y < (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Intersect(const Rect& a, const Circle& b) noexcept
@@ -355,10 +355,10 @@ namespace s3d
 
 		inline constexpr bool Intersect(const RectF& a, const Circle& b) noexcept
 		{
-			const double aw = (a.w * 0.5);
-			const double ah = (a.h * 0.5);
-			const double cX = Abs(b.x - a.x - aw);
-			const double cY = Abs(b.y - a.y - ah);
+			const double aw = (a.size.x * 0.5);
+			const double ah = (a.size.y * 0.5);
+			const double cX = Abs(b.center.x - a.pos.x - aw);
+			const double cY = Abs(b.center.y - a.pos.y - ah);
 
 			if ((cX > (aw + b.r))
 				|| (cY > (ah + b.r)))
@@ -412,7 +412,7 @@ namespace s3d
 
 		inline constexpr bool Intersect(const Circle& a, const Circle& b) noexcept
 		{
-			return (((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y)) <= ((a.r + b.r) * (a.r + b.r)));
+			return (((a.center.x - b.center.x) * (a.center.x - b.center.x) + (a.center.y - b.center.y) * (a.center.y - b.center.y)) <= ((a.r + b.r) * (a.r + b.r)));
 		}
 
 		inline constexpr bool Intersect(const Ellipse& a, const Point& b) noexcept
@@ -1080,18 +1080,18 @@ namespace s3d
 
 		inline constexpr bool Contains(const Rect& a, const Rect& b) noexcept
 		{
-			return (a.x <= b.x)
-				&& (a.y <= b.y)
-				&& ((b.x + b.w) <= (a.x + a.w))
-				&& ((b.y + b.h) <= (a.y + a.h));
+			return (a.pos.x <= b.pos.x)
+				&& (a.pos.y <= b.pos.y)
+				&& ((b.pos.x + b.size.x) <= (a.pos.x + a.size.x))
+				&& ((b.pos.y + b.size.y) <= (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Contains(const Rect& a, const RectF& b) noexcept
 		{
-			return (a.x <= b.x)
-				&& (a.y <= b.y)
-				&& ((b.x + b.w) <= (a.x + a.w))
-				&& ((b.y + b.h) <= (a.y + a.h));
+			return (a.pos.x <= b.pos.x)
+				&& (a.pos.y <= b.pos.y)
+				&& ((b.pos.x + b.size.x) <= (a.pos.x + a.size.x))
+				&& ((b.pos.y + b.size.y) <= (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Contains(const Rect& a, const Circle& b) noexcept
@@ -1144,18 +1144,18 @@ namespace s3d
 
 		inline constexpr bool Contains(const RectF& a, const Rect& b) noexcept
 		{
-			return (a.x <= b.x)
-				&& (a.y <= b.y)
-				&& ((b.x + b.w) <= (a.x + a.w))
-				&& ((b.y + b.h) <= (a.y + a.h));
+			return (a.pos.x <= b.pos.x)
+				&& (a.pos.y <= b.pos.y)
+				&& ((b.pos.x + b.size.x) <= (a.pos.x + a.size.x))
+				&& ((b.pos.y + b.size.y) <= (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Contains(const RectF& a, const RectF& b) noexcept
 		{
-			return (a.x <= b.x)
-				&& (a.y <= b.y)
-				&& ((b.x + b.w) <= (a.x + a.w))
-				&& ((b.y + b.h) <= (a.y + a.h));
+			return (a.pos.x <= b.pos.x)
+				&& (a.pos.y <= b.pos.y)
+				&& ((b.pos.x + b.size.x) <= (a.pos.x + a.size.x))
+				&& ((b.pos.y + b.size.y) <= (a.pos.y + a.size.y));
 		}
 
 		inline constexpr bool Contains(const RectF& a, const Circle& b) noexcept

--- a/Siv3D/include/Siv3D/detail/Quad.ipp
+++ b/Siv3D/include/Siv3D/detail/Quad.ipp
@@ -26,16 +26,16 @@ namespace s3d
 		, p3{ _p3 } {}
 
 	inline constexpr Quad::Quad(const Rect& rect) noexcept
-		: p0{ rect.x, rect.y }
-		, p1{ (rect.x + rect.w), rect.y }
-		, p2{ (rect.x + rect.w), (rect.y + rect.h) }
-		, p3{ rect.x, (rect.y + rect.h) } {}
+		: p0{ rect.pos.x, rect.pos.y }
+		, p1{ (rect.pos.x + rect.size.x), rect.pos.y }
+		, p2{ (rect.pos.x + rect.size.x), (rect.pos.y + rect.size.y) }
+		, p3{ rect.pos.x, (rect.pos.y + rect.size.y) } {}
 
 	inline constexpr Quad::Quad(const RectF& rect) noexcept
-		: p0{ rect.x, rect.y }
-		, p1{ (rect.x + rect.w), rect.y }
-		, p2{ (rect.x + rect.w), (rect.y + rect.h) }
-		, p3{ rect.x, (rect.y + rect.h) } {}
+		: p0{ rect.pos.x, rect.pos.y }
+		, p1{ (rect.pos.x + rect.size.x), rect.pos.y }
+		, p2{ (rect.pos.x + rect.size.x), (rect.pos.y + rect.size.y) }
+		, p3{ rect.pos.x, (rect.pos.y + rect.size.y) } {}
 
 	inline constexpr Quad& Quad::set(const value_type x0, const value_type y0, const value_type x1, const value_type y1, const value_type x2, const value_type y2, const value_type x3, const value_type y3) noexcept
 	{

--- a/Siv3D/include/Siv3D/detail/Rect.ipp
+++ b/Siv3D/include/Siv3D/detail/Rect.ipp
@@ -236,55 +236,55 @@ namespace s3d
 
 	inline constexpr Rect& Rect::setPos(const Arg::topCenter_<position_type> topCenter) noexcept
 	{
-		pos.set((topCenter->x - w / 2), topCenter->y);
+		pos.set((topCenter->x - size.x / 2), topCenter->y);
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::topRight_<position_type> topRight) noexcept
 	{
-		pos.set(topRight->x - w, topRight->y);
+		pos.set(topRight->x - size.x, topRight->y);
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::rightCenter_<position_type> rightCenter) noexcept
 	{
-		pos.set((rightCenter->x - w), (rightCenter->y - h / 2));
+		pos.set((rightCenter->x - size.x), (rightCenter->y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::bottomRight_<position_type> bottomRight) noexcept
 	{
-		pos.set((bottomRight->x - w), (bottomRight->y - h));
+		pos.set((bottomRight->x - size.x), (bottomRight->y - size.y));
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::bottomCenter_<position_type> bottomCenter) noexcept
 	{
-		pos.set((bottomCenter->x - w / 2), (bottomCenter->y - h));
+		pos.set((bottomCenter->x - size.x / 2), (bottomCenter->y - size.y));
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::bottomLeft_<position_type> bottomLeft) noexcept
 	{
-		pos.set(bottomLeft->x, bottomLeft->y - h);
+		pos.set(bottomLeft->x, bottomLeft->y - size.y);
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setPos(const Arg::leftCenter_<position_type> leftCenter) noexcept
 	{
-		pos.set(leftCenter->x, (leftCenter->y - h / 2));
+		pos.set(leftCenter->x, (leftCenter->y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setCenter(const value_type _x, const value_type _y) noexcept
 	{
-		pos.set((_x - w / 2), (_y - h / 2));
+		pos.set((_x - size.x / 2), (_y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr Rect& Rect::setCenter(const position_type _pos) noexcept
 	{
-		pos.set((_pos.x - w / 2), (_pos.y - h / 2));
+		pos.set((_pos.x - size.x / 2), (_pos.y - size.y / 2));
 		return *this;
 	}
 
@@ -860,11 +860,11 @@ namespace s3d
 	{
 		const auto ox = std::max(pos.x, other.pos.x);
 		const auto oy = std::max(pos.y, other.pos.y);
-		const auto ow = (std::min((pos.x + w), (other.pos.x + other.w)) - ox);
+		const auto ow = (std::min((pos.x + size.x), (other.pos.x + other.size.x)) - ox);
 
 		if (0 <= ow)
 		{
-			const auto oh = (std::min((pos.y + h), (other.pos.y + other.h)) - oy);
+			const auto oh = (std::min((pos.y + size.y), (other.pos.y + other.size.y)) - oy);
 
 			if (0 <= oh)
 			{

--- a/Siv3D/include/Siv3D/detail/RectF.ipp
+++ b/Siv3D/include/Siv3D/detail/RectF.ipp
@@ -105,8 +105,8 @@ namespace s3d
 		, size{ _size } {}
 
 	inline constexpr RectF::RectF(const Rect& r) noexcept
-		: pos{ static_cast<value_type>(r.x), static_cast<value_type>(r.y) }
-		, size{ static_cast<value_type>(r.w), static_cast<value_type>(r.h) } {}
+		: pos{ static_cast<value_type>(r.pos.x), static_cast<value_type>(r.pos.y) }
+		, size{ static_cast<value_type>(r.size.x), static_cast<value_type>(r.size.y) } {}
 
 	inline constexpr RectF::RectF(const Arg::center_<position_type> _center, const value_type _size) noexcept
 		: pos{ (_center->x - _size / 2), (_center->y - _size / 2) }
@@ -240,55 +240,55 @@ namespace s3d
 
 	inline constexpr RectF& RectF::setPos(const Arg::topCenter_<position_type> topCenter) noexcept
 	{
-		pos.set((topCenter->x - w / 2), topCenter->y);
+		pos.set((topCenter->x - size.x / 2), topCenter->y);
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::topRight_<position_type> topRight) noexcept
 	{
-		pos.set(topRight->x - w, topRight->y);
+		pos.set(topRight->x - size.x, topRight->y);
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::rightCenter_<position_type> rightCenter) noexcept
 	{
-		pos.set((rightCenter->x - w), (rightCenter->y - h / 2));
+		pos.set((rightCenter->x - size.x), (rightCenter->y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::bottomRight_<position_type> bottomRight) noexcept
 	{
-		pos.set((bottomRight->x - w), (bottomRight->y - h));
+		pos.set((bottomRight->x - size.x), (bottomRight->y - size.y));
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::bottomCenter_<position_type> bottomCenter) noexcept
 	{
-		pos.set((bottomCenter->x - w / 2), (bottomCenter->y - h));
+		pos.set((bottomCenter->x - size.x / 2), (bottomCenter->y - size.y));
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::bottomLeft_<position_type> bottomLeft) noexcept
 	{
-		pos.set(bottomLeft->x, bottomLeft->y - h);
+		pos.set(bottomLeft->x, bottomLeft->y - size.y);
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setPos(const Arg::leftCenter_<position_type> leftCenter) noexcept
 	{
-		pos.set(leftCenter->x, (leftCenter->y - h / 2));
+		pos.set(leftCenter->x, (leftCenter->y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setCenter(const value_type _x, const value_type _y) noexcept
 	{
-		pos.set((_x - w / 2), (_y - h / 2));
+		pos.set((_x - size.x / 2), (_y - size.y / 2));
 		return *this;
 	}
 
 	inline constexpr RectF& RectF::setCenter(const position_type _pos) noexcept
 	{
-		pos.set((_pos.x - w / 2), (_pos.y - h / 2));
+		pos.set((_pos.x - size.x / 2), (_pos.y - size.y / 2));
 		return *this;
 	}
 
@@ -354,8 +354,8 @@ namespace s3d
 
 	inline constexpr RectF& RectF::set(const Rect& r) noexcept
 	{
-		pos.set(static_cast<value_type>(r.x), static_cast<value_type>(r.y));
-		size.set(static_cast<value_type>(r.w), static_cast<value_type>(r.h));
+		pos.set(static_cast<value_type>(r.pos.x), static_cast<value_type>(r.pos.y));
+		size.set(static_cast<value_type>(r.size.x), static_cast<value_type>(r.size.y));
 		return *this;
 	}
 
@@ -870,11 +870,11 @@ namespace s3d
 	{
 		const auto ox = std::max(pos.x, other.pos.x);
 		const auto oy = std::max(pos.y, other.pos.y);
-		const auto ow = (std::min((pos.x + w), (other.pos.x + other.w)) - ox);
+		const auto ow = (std::min((pos.x + size.x), (other.pos.x + other.size.x)) - ox);
 
 		if (0 <= ow)
 		{
-			const auto oh = (std::min((pos.y + h), (other.pos.y + other.h)) - oy);
+			const auto oh = (std::min((pos.y + size.y), (other.pos.y + other.size.y)) - oy);
 
 			if (0 <= oh)
 			{

--- a/Siv3D/include/Siv3D/detail/RoundRect.ipp
+++ b/Siv3D/include/Siv3D/detail/RoundRect.ipp
@@ -105,7 +105,7 @@ namespace s3d
 
 	inline constexpr RoundRect& RoundRect::set(const RectF& _rect, const value_type _r) noexcept
 	{
-		return set(_rect.x, _rect.y, _rect.w, _rect.h, _r);
+		return set(_rect.pos.x, _rect.pos.y, _rect.size.x, _rect.size.y, _r);
 	}
 
 	inline constexpr RoundRect& RoundRect::set(const RoundRect& roundRect) noexcept


### PR DESCRIPTION
#1139 の pull-request です。
