### PR TITLE
fix JSON

### DIFF
--- a/Siv3D/include/Siv3D/JSON.hpp
+++ b/Siv3D/include/Siv3D/JSON.hpp
@@ -529,7 +529,7 @@ namespace s3d
 		void push_back(const JSON& value);
 
 		/// @brief 所有しているデータを消去して空にします。
-		void clear() const;
+		void clear();
 
 		/// @brief 渡されたキーが指す要素を削除します。
 		/// @param [in] name キー

--- a/Siv3D/include/Siv3D/JSON.hpp
+++ b/Siv3D/include/Siv3D/JSON.hpp
@@ -248,10 +248,10 @@ namespace s3d
 		JSON(std::nullptr_t);
 
 		SIV3D_NODISCARD_CXX20
-		JSON(const JSON&) = default;
+		JSON(const JSON& other);
 
 		SIV3D_NODISCARD_CXX20
-		JSON(JSON&&) = default;
+		JSON(JSON&& other) noexcept;
 
 		SIV3D_NODISCARD_CXX20
 		JSON(const std::initializer_list<std::pair<String, JSON>>& list);
@@ -307,6 +307,8 @@ namespace s3d
 
 		// JSONValueType::Object
 		JSON& operator =(const JSON& value);
+
+		JSON& operator =(JSON&& value) noexcept;
 
 		// JSONValueType::Object
 		JSON& operator =(const std::initializer_list<std::pair<String, JSON>>& list);
@@ -636,6 +638,19 @@ namespace s3d
 		/// @return MessagePack データ
 		[[nodiscard]]
 		Blob toMessagePack() const;
+
+		/// @brief JSON オブジェクトを交換します。
+		/// @param other 交換する JSON オブジェクト
+		void swap(JSON& other) noexcept;
+
+		/// @brief 2 つの JSON オブジェクトを交換します。
+		/// @param lhs JSON オブジェクト
+		/// @param rhs JSON オブジェクト
+		friend void swap(JSON& lhs, JSON& rhs) noexcept
+		{
+			lhs.m_detail.swap(rhs.m_detail);
+			std::swap(lhs.m_isValid, rhs.m_isValid);
+		}
 
 		// @brief 無効な JSON オブジェクトを返します。
 		// @return 無効な JSON オブジェクト

--- a/Siv3D/include/Siv3D/JSON.hpp
+++ b/Siv3D/include/Siv3D/JSON.hpp
@@ -251,7 +251,7 @@ namespace s3d
 		JSON(const JSON& other);
 
 		SIV3D_NODISCARD_CXX20
-		JSON(JSON&& other) noexcept;
+		JSON(JSON&& other);
 
 		SIV3D_NODISCARD_CXX20
 		JSON(const std::initializer_list<std::pair<String, JSON>>& list);

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -496,7 +496,7 @@ namespace s3d
 		: m_detail{ std::make_shared<detail::JSONDetail>(*other.m_detail) }
 		, m_isValid{ other.m_isValid } {}
 
-	JSON::JSON(JSON&& other) noexcept
+	JSON::JSON(JSON&& other)
 		: m_detail{ std::exchange(other.m_detail, std::make_shared<detail::JSONDetail>()) }
 		, m_isValid{ std::exchange(other.m_isValid, false) } {}
 

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -546,7 +546,7 @@ namespace s3d
 
 	JSON& JSON::operator =(JSON&& other) noexcept
 	{
-		m_detail = std::exchange(other.m_detail, std::make_shared<detail::JSONDetail>());
+		*m_detail = std::exchange(*other.m_detail, detail::JSONDetail{});
 		m_isValid = std::exchange(other.m_isValid, false);
 		return *this;
 	}

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -929,7 +929,7 @@ namespace s3d
 		m_detail->get().push_back(value.m_detail->get());
 	}
 
-	void JSON::clear() const
+	void JSON::clear()
 	{
 		if (not m_isValid)
 		{

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -492,6 +492,14 @@ namespace s3d
 	JSON::JSON(std::nullptr_t)
 		: m_detail{ std::make_shared<detail::JSONDetail>() } {}
 
+	JSON::JSON(const JSON& other)
+		: m_detail{ std::make_shared<detail::JSONDetail>(*other.m_detail) }
+		, m_isValid{ other.m_isValid } {}
+
+	JSON::JSON(JSON&& other) noexcept
+		: m_detail{ std::exchange(other.m_detail, std::make_shared<detail::JSONDetail>()) }
+		, m_isValid{ std::exchange(other.m_isValid, false) } {}
+
 	JSON::JSON(std::shared_ptr<detail::JSONDetail>&& detail)
 		: m_detail{ std::move(detail) } {}
 
@@ -524,122 +532,83 @@ namespace s3d
 
 	JSON& JSON::operator =(std::nullptr_t)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = nullptr;
-
+		m_isValid = true;
 		return *this;
 	}
 
-	JSON& JSON::operator =(const JSON& value)
+	JSON& JSON::operator =(const JSON& other)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
+		m_detail = std::make_shared<detail::JSONDetail>(*other.m_detail);
+		m_isValid = other.m_isValid;
+		return *this;
+	}
 
-		m_detail->get() = value.m_detail->get();
-
+	JSON& JSON::operator =(JSON&& other) noexcept
+	{
+		m_detail = std::exchange(other.m_detail, std::make_shared<detail::JSONDetail>());
+		m_isValid = std::exchange(other.m_isValid, false);
 		return *this;
 	}
 
 	JSON& JSON::operator =(const std::initializer_list<std::pair<String, JSON>>& list)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
+		m_detail->get().clear();
 
 		for (const auto& element : list)
 		{
 			m_detail->get()[Unicode::ToUTF8(element.first)] = element.second.m_detail->get();
 		}
 
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const Array<JSON>& array)
 	{
-		if (not m_isValid)
+		m_detail->get() = nlohmann::json::array();
+
+		for (const auto& element : array)
 		{
-			return *this;
+			m_detail->get().push_back(element.m_detail->get());
 		}
 
-		if (array)
-		{
-			for (const auto& element : array)
-			{
-				m_detail->get().push_back(element.m_detail->get());
-			}
-		}
-		else
-		{
-			m_detail->get() = nlohmann::json::array();
-		}
-
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const StringView value)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = Unicode::ToUTF8(value);
-
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const int64 value)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = value;
-
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const uint64 value)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = value;
-
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const double value)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = value;
-
+		m_isValid = true;
 		return *this;
 	}
 
 	JSON& JSON::operator =(const bool value)
 	{
-		if (not m_isValid)
-		{
-			return *this;
-		}
-
 		m_detail->get() = value;
-
+		m_isValid = true;
 		return *this;
 	}
 
@@ -1154,6 +1123,12 @@ namespace s3d
 		std::vector<uint8> result;
 		nlohmann::json::to_msgpack(m_detail->get(), result);
 		return Blob{ result.data(), result.size() };
+	}
+
+	void JSON::swap(JSON& other) noexcept
+	{
+		m_detail.swap(other.m_detail);
+		std::swap(m_isValid, other.m_isValid);
 	}
 
 	JSON JSON::Invalid()

--- a/Siv3D/src/Siv3D/JSON/SivJSON.cpp
+++ b/Siv3D/src/Siv3D/JSON/SivJSON.cpp
@@ -498,7 +498,7 @@ namespace s3d
 
 	JSON::JSON(JSON&& other)
 		: m_detail{ std::exchange(other.m_detail, std::make_shared<detail::JSONDetail>()) }
-		, m_isValid{ std::exchange(other.m_isValid, false) } {}
+		, m_isValid{ std::exchange(other.m_isValid, true) } {}
 
 	JSON::JSON(std::shared_ptr<detail::JSONDetail>&& detail)
 		: m_detail{ std::move(detail) } {}
@@ -547,7 +547,7 @@ namespace s3d
 	JSON& JSON::operator =(JSON&& other) noexcept
 	{
 		*m_detail = std::exchange(*other.m_detail, detail::JSONDetail{});
-		m_isValid = std::exchange(other.m_isValid, false);
+		m_isValid = std::exchange(other.m_isValid, true);
 		return *this;
 	}
 


### PR DESCRIPTION
- コピーコンストラクタ・ムーブコンストラクタの問題を修正 #1117
- `swap` を定義
- Invalid な JSON への代入を有効に
- `JSON::operator =(const std::initializer_list<std::pair<String, JSON>>& list)` および  `JSON::operator =(const Array<JSON>& array)` が古い内容を消去していなかったバグを修正 #1166


