### PR TITLE
幅or高さがImageの上限(16384px)より大きいGIFファイルを読むとアクセス違反が起きるのを修正

### DIFF
--- a/Siv3D/src/Siv3D/ImageFormat/GIF/GIFDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/GIF/GIFDecoder.cpp
@@ -159,10 +159,19 @@ namespace s3d
 
 		if ((width == 0) || (height == 0))
 		{
+			DGifCloseFile(gif, &error);
+
 			return{};
 		}
 
 		Image image{ width, height };
+		if (!image)
+		{
+			DGifCloseFile(gif, &error);
+
+			return{};
+		}
+
 		Color* pDst = image.data();
 
 		for (size_t y = 0; y < height; ++y)


### PR DESCRIPTION
下記の不具合を修正しました。ご確認をお願いいたします。

# 不具合内容
Imageクラスで幅または高さが16384pxより大きいGIF画像を読み込もうとするとメモリアクセス違反が起きてプログラムがクラッシュする。

# 不具合原因
Imageクラスの幅・高さは16384pxが上限(`Image::MaxWidth`、`Image::MaxHeight`)なので、それより大きいサイズで生成しようとするとImageクラスのコンストラクタで0px扱いになる。

しかし、`GIFDecoder::decode`内の下記では指定した幅・高さで初期化されていることを前提にポインタで操作していたため、Imageの幅または高さが0px扱いになった場合にはポインタが範囲外のアドレスを参照してアクセス違反が生じていた。
https://github.com/Siv3D/OpenSiv3D/blob/d6bff5978dff6046fbb05d70e80eb296a84b74a5/Siv3D/src/Siv3D/ImageFormat/GIF/GIFDecoder.cpp#L165-L182

# 修正内容
`Image::operator bool()`がfalseを返す(＝画像が空である)場合はデコードを止めるように修正。
また、本件と直接関係はないがDGifCloseFileに漏れがあった箇所も修正。