### PR TITLE
ImageDecoder::GetImageInfoで取得されるGIF画像の解像度が正しくないのを修正

### DIFF
--- a/Siv3D/src/Siv3D/ImageFormat/GIF/GIFDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/GIF/GIFDecoder.cpp
@@ -63,7 +63,7 @@ namespace s3d
 
 	Optional<ImageInfo> GIFDecoder::getImageInfo(IReader& reader, const FilePathView) const
 	{
-		uint8 buf[4];
+		uint8 buf[10];
 
 		if (not reader.lookahead(buf))
 		{
@@ -71,8 +71,8 @@ namespace s3d
 			return{};
 		}
 
-		const int32 width = ((buf[1] << 8) + (buf[0] << 0));
-		const int32 height = ((buf[3] << 8) + (buf[2] << 0));
+		const int32 width = ((buf[7] << 8) + (buf[6] << 0));
+		const int32 height = ((buf[9] << 8) + (buf[8] << 0));
 		const Size size{ width, height };
 		
 		ImagePixelFormat pixelFormat = ImagePixelFormat::R8G8B8A8;


### PR DESCRIPTION
下記の不具合を修正しました。ご確認をお願いいたします。

# 不具合内容
`ImageDecoder::GetImageInfo`でGIF画像の解像度を取得すると、`ImageInfo::size`に必ず「18759px×14406px」が取得されており、結果が正しくない。

# 不具合原因
本来7・8バイト目を幅、9・10バイト目を高さとして取り扱うべきところが、それぞれ1・2バイト目、3・4バイト目が読み込まれていた。
GIFファイルのヘッダの先頭4バイトは毎回同じデータ("`GIF8`")なので、毎回同じ結果(18759px×14406px)となっていた。

# 修正内容
先頭10バイトを読み込んで、7・8バイト目を幅、9・10バイト目を高さとして取り扱うよう修正。