### PR TITLE
一部Windows環境にてVSync無効時にフレームレートが制限される現象を修正

### DIFF
--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.cpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.cpp
@@ -44,12 +44,30 @@ namespace s3d
 			::DwmGetCompositionTimingInfo(nullptr, &timingInfo);
 			return ToMillisec(timingInfo.qpcRefreshPeriod);
 		}
+
+		[[nodiscard]]
+		static bool CheckTearingSupport(const D3D11Device& device)
+		{
+			IDXGIFactory5* const factory = device.getDXGIFactory5();
+			if (factory == nullptr)
+			{
+				return false;
+			}
+
+			BOOL allowTearing = FALSE;
+			const HRESULT hr = factory->CheckFeatureSupport(
+				DXGI_FEATURE_PRESENT_ALLOW_TEARING,
+				&allowTearing,
+				sizeof(allowTearing));
+			return SUCCEEDED(hr) && allowTearing == TRUE;
+		}
 	}
 
 	D3D11SwapChain::D3D11SwapChain(const D3D11Device& device, HWND hWnd, const Size& frameBufferSize)
 		: m_hWnd(hWnd)
 		, m_device(device.getDevice())
 		, m_context(device.getContext())
+		, m_tearingSupport(detail::CheckTearingSupport(device))
 	{
 		LOG_SCOPED_TRACE(U"D3D11SwapChain::D3D11SwapChain()");
 
@@ -63,7 +81,7 @@ namespace s3d
 		m_desc.Scaling		= DXGI_SCALING_STRETCH;
 		m_desc.SwapEffect	= (device.getDXGIFactory5() ? DXGI_SWAP_EFFECT_FLIP_DISCARD : DXGI_SWAP_EFFECT_DISCARD);
 		m_desc.AlphaMode	= DXGI_ALPHA_MODE_IGNORE;
-		m_desc.Flags		= 0;
+		m_desc.Flags		= m_tearingSupport ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
 
 		// Swap chain を作成
 		{
@@ -258,7 +276,8 @@ namespace s3d
 		}
 		*/
 
-		const HRESULT hr = m_swapChain1->Present(0, 0);
+		const UINT presentFlags = m_tearingSupport ? DXGI_PRESENT_ALLOW_TEARING : 0;
+		const HRESULT hr = m_swapChain1->Present(0, presentFlags);
 
 		if (hr == DXGI_STATUS_OCCLUDED)
 		{

--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.hpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.hpp
@@ -27,6 +27,8 @@ namespace s3d
 		
 		ID3D11DeviceContext* m_context	= nullptr;
 
+		bool m_tearingSupport;
+
 		DXGI_SWAP_CHAIN_DESC1 m_desc	= {};
 
 		ComPtr<IDXGISwapChain1> m_swapChain1;


### PR DESCRIPTION
## 起きていた現象
一部Windows環境にて、VSyncを無効にした場合でもフレームレートが120fpsに制限されている。
ウィンドウモード、フルスクリーンモードの両方で発生する。
※垂直同期有効時は60fpsとなっている。

発生を確認している環境:
- Windows 10 22H2 (19045.3803)
- CPU: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz、3601 Mhz、8 個のコア、16 個のロジカル プロセッサ
- GPU: NVIDIA GeForce RTX 3070 (ドライババージョン: 536.40)
- NVIDIAコントロールパネルの「垂直同期」設定値: 「3D アプリケーション設定を使用する」
    - 「垂直同期」の設定値を「オフ」に変更すると現象は発生しなくなるが、垂直同期が有効な全アプリケーションで垂直同期が無効になってしまう
- 解像度: 1920 x 1080 x 60 ヘルツ

下記のQiita記事に「注意点」として記載している現象と同一のものです。
[OpenSiv3Dでフレームレートを60fps以外に固定する方法(FrameRateLimitアドオン)](https://qiita.com/m4saka/items/5da6cd4b57bc894d35dd#%E6%B3%A8%E6%84%8F%E7%82%B9)

## 現象の原因
DirectXのSwapChainのPresent時に、VSync無効時に可変フレームレートにするために必要となるティアリング許可フラグが立っていないため。

## 修正内容
SwapChainの初期化時に、サポートされている場合は`DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING`フラグを立てるように。
また、VSync無効かつサポートされている場合はPresent時に`DXGI_PRESENT_ALLOW_TEARING`フラグを立てるように。

サポートされているかどうかを調べるCheckTearingSupport関数の実装にあたっては、Microsoft公式が出している下記サンプルコードを参考にしました。
https://github.com/microsoft/DirectX-Graphics-Samples/blob/b5f92e2251ee83db4d4c795b3cba5d470c52eaf8/Samples/UWP/D3D12HDR/src/DXSample.cpp#L160

## 補足
`DXGI_PRESENT_ALLOW_TEARING`について、Microsoft公式には下記のように「ウィンドウ モードでのみ使用できます」という一見紛らわしい記載がありますが、OpenSiv3Dでは「`IDXGIFactory::MakeWindowAssociation` を使用して Alt + Enter の全画面表示の自動切り替えを無効」にしている([該当箇所](https://github.com/Siv3D/OpenSiv3D/blob/64d05c1217da7d7f4bc14aa2a7838acb26a8829d/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.cpp#L83-L92))ので、フルスクリーンモードでも使用できています。

実際に、修正前はフルスクリーンモードでも現象が発生しており、修正後はフルスクリーンモードでも現象が発生しなくなったことを確認しました。

https://learn.microsoft.com/ja-jp/windows/win32/direct3ddxgi/dxgi-present
> DXGI_PRESENT_ALLOW_TEARING フラグは、現在全画面表示排他モードのアプリケーションでは使用できません ( `SetFullscreenState(TRUE)`を呼び出して設定)。 ウィンドウ モードでのみ使用できます。 全画面表示の Win32 アプリでこのフラグを使用するには、アプリケーションを全画面表示の境界線のないウィンドウに表示し、 `IDXGIFactory::MakeWindowAssociation` を使用して Alt + Enter の全画面表示の自動切り替えを無効にする必要があります。 を呼び出 `Windows::UI::ViewManagement::ApplicationView::TryEnterFullscreen()` して全画面表示モードに入る UWP アプリは、全画面表示の境界線のないウィンドウであり、 フラグを使用できます。