### PR TITLE
MultiPolygonにおける範囲for文の*thisをm_dataへ変更(#1188)

### DIFF
--- a/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
+++ b/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
@@ -123,7 +123,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::moveBy(const double x, const double y) noexcept
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.moveBy(x, y);
 		}
@@ -158,7 +158,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::rotate(const double angle)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.rotate(angle);
 		}
@@ -168,7 +168,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::rotateAt(const Vec2& pos, const double angle)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.rotateAt(pos, angle);
 		}
@@ -188,7 +188,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::transform(const double s, const double c, const Vec2& pos)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.transform(s, c, pos);
 		}
@@ -228,7 +228,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::scale(const double s)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.scale(s);
 		}
@@ -243,7 +243,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::scale(const Vec2 s)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.scale(s);
 		}
@@ -263,7 +263,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::scaleAt(const Vec2 pos, const double s)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.scaleAt(pos, s);
 		}
@@ -298,7 +298,7 @@ namespace s3d
 
 	MultiPolygon& MultiPolygon::scaleAt(const Vec2 pos, const Vec2 s)
 	{
-		for (auto& polygon : *this)
+		for (auto& polygon : m_data)
 		{
 			polygon.scaleAt(pos, s);
 		}
@@ -396,7 +396,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::paint(Image& dst, const Color& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.paint(dst, color);
 		}
@@ -408,7 +408,7 @@ namespace s3d
 	{
 		const Vec2 pos{ x, y };
 
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.paint(dst, pos, color);
 		}
@@ -418,7 +418,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::paint(Image& dst, const Vec2& pos, const Color& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.paint(dst, pos, color);
 		}
@@ -428,7 +428,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::overwrite(Image& dst, const Color& color, const Antialiased antialiased) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.overwrite(dst, color, antialiased);
 		}
@@ -440,7 +440,7 @@ namespace s3d
 	{
 		const Vec2 pos{ x, y };
 
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.overwrite(dst, pos, color, antialiased);
 		}
@@ -450,7 +450,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::overwrite(Image& dst, const Vec2& pos, const Color& color, const Antialiased antialiased) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.overwrite(dst, pos, color, antialiased);
 		}
@@ -460,7 +460,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::draw(const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.draw(color);
 		}
@@ -470,7 +470,7 @@ namespace s3d
 
 	void MultiPolygon::draw(const double x, const double y, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.draw(x, y, color);
 		}
@@ -478,7 +478,7 @@ namespace s3d
 
 	void MultiPolygon::draw(const Vec2& pos, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.draw(pos, color);
 		}
@@ -486,7 +486,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::drawFrame(const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawFrame(thickness, color);
 		}
@@ -496,7 +496,7 @@ namespace s3d
 
 	void MultiPolygon::drawFrame(const double x, const double y, const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawFrame(x, y, thickness, color);
 		}
@@ -504,7 +504,7 @@ namespace s3d
 
 	void MultiPolygon::drawFrame(const Vec2& pos, const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawFrame(pos, thickness, color);
 		}
@@ -512,7 +512,7 @@ namespace s3d
 
 	const MultiPolygon& MultiPolygon::drawWireframe(const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawWireframe(thickness, color);
 		}
@@ -522,7 +522,7 @@ namespace s3d
 
 	void MultiPolygon::drawWireframe(const double x, const double y, const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawWireframe(x, y, thickness, color);
 		}
@@ -530,7 +530,7 @@ namespace s3d
 
 	void MultiPolygon::drawWireframe(const Vec2& pos, const double thickness, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawWireframe(pos, thickness, color);
 		}
@@ -540,7 +540,7 @@ namespace s3d
 	{
 		const auto [s, c] = FastMath::SinCos(angle);
 
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawTransformed(s, c, pos, color);
 		}
@@ -548,7 +548,7 @@ namespace s3d
 
 	void MultiPolygon::drawTransformed(const double s, const double c, const Vec2& pos, const ColorF& color) const
 	{
-		for (const auto& polygon : *this)
+		for (const auto& polygon : m_data)
 		{
 			polygon.drawTransformed(s, c, pos, color);
 		}


### PR DESCRIPTION
MultiPolygonにて最適化無しの際の関数呼び出しを削減するため、`for(auto& polygon : *this)`を`for(auto& polygon : m_data)`に変更。(#1188 )