### PR TITLE
MultiPolygon::centroid()の実装(#1186)

### DIFF
--- a/Siv3D/include/Siv3D/MultiPolygon.hpp
+++ b/Siv3D/include/Siv3D/MultiPolygon.hpp
@@ -418,6 +418,9 @@ namespace s3d
 		double perimeter() const noexcept;
 
 		[[nodiscard]]
+		Vec2 centroid() const;
+
+		[[nodiscard]]
 		RectF computeBoundingRect() const noexcept;
 
 		[[nodiscard]]

--- a/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
+++ b/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
@@ -330,6 +330,19 @@ namespace s3d
 		return total;
 	}
 
+	Vec2 MultiPolygon::centroid() const
+	{
+		Vec2 weightedCoordsTotal{ 0, 0 };
+		double areaTotal = 0;
+		for (const auto& polygon : m_data)
+		{
+			double polygonArea = polygon.area();
+			weightedCoordsTotal += polygonArea * polygon.centroid();
+			areaTotal += polygonArea;
+		}
+		return weightedCoordsTotal / areaTotal;
+	}
+
 	RectF MultiPolygon::computeBoundingRect() const noexcept
 	{
 		if (isEmpty())

--- a/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
+++ b/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
@@ -332,11 +332,14 @@ namespace s3d
 
 	Vec2 MultiPolygon::centroid() const
 	{
+		if (m_data.empty()) {
+			return Vec2{ 0, 0 };
+		}
 		Vec2 weightedCoordsTotal{ 0, 0 };
 		double areaTotal = 0;
 		for (const auto& polygon : m_data)
 		{
-			double polygonArea = polygon.area();
+			const double polygonArea = polygon.area();
 			weightedCoordsTotal += polygonArea * polygon.centroid();
 			areaTotal += polygonArea;
 		}

--- a/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
+++ b/Siv3D/src/Siv3D/MultiPolygon/SivMultiPolygon.cpp
@@ -332,17 +332,21 @@ namespace s3d
 
 	Vec2 MultiPolygon::centroid() const
 	{
-		if (m_data.empty()) {
+		if (m_data.empty())
+		{
 			return Vec2{ 0, 0 };
 		}
+		
 		Vec2 weightedCoordsTotal{ 0, 0 };
-		double areaTotal = 0;
+		double areaTotal = 0.0;
+		
 		for (const auto& polygon : m_data)
 		{
 			const double polygonArea = polygon.area();
 			weightedCoordsTotal += polygonArea * polygon.centroid();
 			areaTotal += polygonArea;
 		}
+		
 		return weightedCoordsTotal / areaTotal;
 	}
 


### PR DESCRIPTION
#1186 
MultiPolygon::centroid()を実装しました。
実装の際、変数名が思い浮かばず、長くなってしまいました……。

重心を求めるために$`S, v`$をそれぞれ、各Polygonの面積、重心として以下の式で求めました。
$$\frac{S_0v_0+S_1v_1+\cdots +S_{N-1}v_{N-1}}{S_0+S_1+\cdots +S_{N-1}}$$