### PR TITLE
VSync無効時にフレームレートを制限する機能を追加

### DIFF
--- a/Linux/CMakeLists.txt
+++ b/Linux/CMakeLists.txt
@@ -300,6 +300,8 @@ set(SIV3D_INTERNAL_SOURCES
   ../Siv3D/src/Siv3D/FormatInt/SivFormatInt.cpp
   ../Siv3D/src/Siv3D/Formatter/SivFormatter.cpp
   ../Siv3D/src/Siv3D/FormatUtility/SivFormatUtility.cpp
+  ../Siv3D/src/Siv3D/FrameRateLimit/SivFrameRateLimit.cpp
+  ../Siv3D/src/Siv3D/FrameRateLimit/FrameRateLimitFactory.cpp
   ../Siv3D/src/Siv3D/Gamepad/GamepadFactory.cpp
   ../Siv3D/src/Siv3D/Gamepad/SivGamepad.cpp
   ../Siv3D/src/Siv3D/GamepadInfo/SivGamepadInfo.cpp

--- a/Siv3D/include/Siv3D/Graphics.hpp
+++ b/Siv3D/include/Siv3D/Graphics.hpp
@@ -11,6 +11,7 @@
 
 # pragma once
 # include "Common.hpp"
+# include "Optional.hpp"
 
 namespace s3d
 {
@@ -27,5 +28,15 @@ namespace s3d
 		/// @return VSync が有効である場合 true, 無効である場合 false
 		[[nodiscard]]
 		bool IsVSyncEnabled();
+
+		/// @brief VSync 無効時の目標フレームレートを設定します。
+		/// @param fps 目標フレームレート（FPS）。フレームレート制限を無効にする場合は none
+		/// @remark デフォルトでは none です。
+		void SetTargetFrameRate(const Optional<double>& fps);
+
+		/// @brief VSync 無効時の目標フレームレートを取得します。
+		/// @return 目標フレームレート（FPS）。フレームレート制限が無効の場合は none
+		[[nodiscard]]
+		Optional<double> GetTargetFrameRate();
 	}
 }

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/System/CSystem.cpp
@@ -51,6 +51,7 @@
 # include <Siv3D/Effect/IEffect.hpp>
 # include <Siv3D/Script/IScript.hpp>
 # include <Siv3D/Addon/IAddon.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 # include <Siv3D/System/SystemLog.hpp>
 # include <Siv3D/System/SystemMisc.hpp>
 # include "CSystem.hpp"
@@ -131,6 +132,7 @@ namespace s3d
 		SIV3D_ENGINE(Renderer)->present();
 		SIV3D_ENGINE(ScreenCapture)->update();
 		SIV3D_ENGINE(Addon)->postPresent();
+		SIV3D_ENGINE(FrameRateLimit)->update();
 		
 		//
 		// previous frame

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/System/CSystem.cpp
@@ -50,6 +50,7 @@
 # include <Siv3D/Asset/IAsset.hpp>
 # include <Siv3D/Effect/IEffect.hpp>
 # include <Siv3D/Addon/IAddon.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 # include <Siv3D/Script/IScript.hpp>
 # include <Siv3D/System/SystemLog.hpp>
 # include <Siv3D/System/SystemMisc.hpp>
@@ -151,6 +152,7 @@ namespace s3d
 		SIV3D_ENGINE(Renderer)->present();
 		SIV3D_ENGINE(ScreenCapture)->update();
 		SIV3D_ENGINE(Addon)->postPresent();
+		SIV3D_ENGINE(FrameRateLimit)->update();
 
 		detail::siv3dRequestAnimationFrame();
 		

--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.cpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.cpp
@@ -138,9 +138,6 @@ namespace s3d
 			m_previousWindowBounds = windowBounds;
 		}
 
-		//const bool vSync = (not m_targetFrameRateHz.has_value())
-		//	|| ((30.0 <= m_targetFrameRateHz) && (AbsDiff(m_targetFrameRateHz.value(), m_displayFrequency) <= 3.0));
-
 		return vSync ? presentVSync() : presentNonVSync();
 	}
 
@@ -148,16 +145,6 @@ namespace s3d
 	{
 		return m_displayFrequency;
 	}
-
-	//void D3D11SwapChain::setTargetFrameRateHz(const Optional<double>& targetFrameRateHz)
-	//{
-	//	m_targetFrameRateHz = targetFrameRateHz;
-	//}
-
-	//const Optional<double>& D3D11SwapChain::getTargetFrameRateHz() const noexcept
-	//{
-	//	return m_targetFrameRateHz;
-	//}
 
 	IDXGISwapChain1* D3D11SwapChain::getSwapChain1() const noexcept
 	{
@@ -245,37 +232,6 @@ namespace s3d
 
 	bool D3D11SwapChain::presentNonVSync()
 	{
-		/*
-		const double targetRefreshRateHz = m_targetFrameRateHz.value();
-		const double targetRefreshPeriodMillisec = (1000.0 / targetRefreshRateHz);
-		const double displayRefreshPeriodMillisec = detail::GetDisplayRefreshPeriodMillisec();
-
-		LARGE_INTEGER counter;
-		::QueryPerformanceCounter(&counter);
-
-		{
-			m_context->Flush();
-
-			double timeToSleepMillisec = 0.0;
-			::timeBeginPeriod(1);
-
-			do
-			{
-				::QueryPerformanceCounter(&counter);
-				const double timeSinceFlipMillisec = detail::ToMillisec(counter.QuadPart - m_lastPresentTime);
-
-				timeToSleepMillisec = (targetRefreshPeriodMillisec - timeSinceFlipMillisec);
-
-				if (timeToSleepMillisec > 0.0)
-				{
-					::Sleep(static_cast<int32>(timeToSleepMillisec));
-				}
-			} while (timeToSleepMillisec > 0.5);
-
-			::timeEndPeriod(1);
-		}
-		*/
-
 		const UINT presentFlags = m_tearingSupport ? DXGI_PRESENT_ALLOW_TEARING : 0;
 		const HRESULT hr = m_swapChain1->Present(0, presentFlags);
 
@@ -293,8 +249,6 @@ namespace s3d
 			LOG_FAIL(U"❌ IDXGISwapChain::Present() failed (DXGI_ERROR_DEVICE_REMOVED)");
 			return false;
 		}
-
-		//m_lastPresentTime = counter.QuadPart;
 
 		return true;
 	}

--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.hpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Renderer/D3D11/SwapChain/D3D11SwapChain.hpp
@@ -59,11 +59,6 @@ namespace s3d
 		[[nodiscard]]
 		double getDisplayFrequency() const noexcept;
 
-		//void setTargetFrameRateHz(const Optional<double>& targetFrameRateHz);
-
-		//[[nodiscard]]
-		//const Optional<double>& getTargetFrameRateHz() const noexcept;
-
 		[[nodiscard]]
 		IDXGISwapChain1* getSwapChain1() const noexcept;
 

--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/System/CSystem.cpp
@@ -52,6 +52,7 @@
 # include <Siv3D/Asset/IAsset.hpp>
 # include <Siv3D/Effect/IEffect.hpp>
 # include <Siv3D/Addon/IAddon.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 # include <Siv3D/System/SystemLog.hpp>
 # include <Siv3D/System/SystemMisc.hpp>
 # include <Siv3D/Windows/Windows.hpp>
@@ -177,6 +178,7 @@ namespace s3d
 		SIV3D_ENGINE(Renderer)->present();
 		SIV3D_ENGINE(ScreenCapture)->update();
 		SIV3D_ENGINE(Addon)->postPresent();
+		SIV3D_ENGINE(FrameRateLimit)->update();
 
 		//
 		// previous frame

--- a/Siv3D/src/Siv3D-Platform/macOS/Siv3D/System/CSystem.cpp
+++ b/Siv3D/src/Siv3D-Platform/macOS/Siv3D/System/CSystem.cpp
@@ -51,6 +51,7 @@
 # include <Siv3D/Effect/IEffect.hpp>
 # include <Siv3D/Script/IScript.hpp>
 # include <Siv3D/Addon/IAddon.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 # include <Siv3D/System/SystemLog.hpp>
 # include <Siv3D/System/SystemMisc.hpp>
 # include "CSystem.hpp"
@@ -131,6 +132,7 @@ namespace s3d
 		SIV3D_ENGINE(Renderer)->present();
 		SIV3D_ENGINE(ScreenCapture)->update();
 		SIV3D_ENGINE(Addon)->postPresent();
+		SIV3D_ENGINE(FrameRateLimit)->update();
 		
 		//
 		// previous frame

--- a/Siv3D/src/Siv3D/Common/Siv3DEngine.cpp
+++ b/Siv3D/src/Siv3D/Common/Siv3DEngine.cpp
@@ -58,6 +58,7 @@
 # include <Siv3D/TrailRenderer/ITrailRenderer.hpp>
 # include <Siv3D/Script/IScript.hpp>
 # include <Siv3D/Addon/IAddon.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 
 namespace s3d
 {

--- a/Siv3D/src/Siv3D/Common/Siv3DEngine.hpp
+++ b/Siv3D/src/Siv3D/Common/Siv3DEngine.hpp
@@ -63,6 +63,7 @@ namespace s3d
 	class ISiv3DTrailRenderer;
 	class ISiv3DScript;
 	class ISiv3DAddon;
+	class ISiv3DFrameRateLimit;
 
 	class Siv3DEngine
 	{
@@ -118,7 +119,8 @@ namespace s3d
 			Siv3DComponent<ISiv3DEffect>,
 			Siv3DComponent<ISiv3DTrailRenderer>,
 			Siv3DComponent<ISiv3DScript>,
-			Siv3DComponent<ISiv3DAddon>> m_components;
+			Siv3DComponent<ISiv3DAddon>,
+			Siv3DComponent<ISiv3DFrameRateLimit>> m_components;
 
 	public:
 

--- a/Siv3D/src/Siv3D/FrameRateLimit/CFrameRateLimit.hpp
+++ b/Siv3D/src/Siv3D/FrameRateLimit/CFrameRateLimit.hpp
@@ -1,0 +1,86 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2023 Ryo Suzuki
+//	Copyright (c) 2016-2023 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include "IFrameRateLimit.hpp"
+
+namespace s3d
+{
+	class CFrameRateLimit final : public ISiv3DFrameRateLimit
+	{
+	public:
+
+		using clock_type = std::chrono::steady_clock;
+
+		/// @brief フレームレート制限を実行します。
+		void update() override;
+
+		/// @brief 目標フレームレートを設定します。
+		/// @param fps 目標フレームレート（FPS）。フレームレート制限を無効にする場合は none
+		void setTargetFrameRate(const Optional<double>& fps) override;
+
+		/// @brief 目標フレームレートを取得します。
+		/// @return 目標フレームレート（FPS）。フレームレート制限が無効の場合は none
+		SIV3D_NODISCARD_CXX20
+		Optional<double> getTargetFrameRate() const override;
+
+	private:
+
+		class Limiter
+		{
+		public:
+
+			/// @brief コンストラクタ
+			/// @param fps 目標フレームレート（FPS）
+			/// @throw Error fps が無効な値の場合
+			SIV3D_NODISCARD_CXX20
+			explicit Limiter(double fps);
+
+			/// @brief sleepを実行し、フレームを次に進めます。
+			void doSleep();
+
+			/// @brief 目標フレームレートを設定します。
+			/// @param targetFrameRate 目標フレームレート（FPS）
+			/// @throw Error fps が無効な値の場合
+			void setTargetFrameRate(double fps);
+
+			/// @brief 目標フレームレートを取得します。
+			/// @return 目標フレームレート（FPS）
+			SIV3D_NODISCARD_CXX20
+			double getTargetFrameRate() const noexcept { return m_fps; }
+
+		private:
+
+			/// @brief 1秒間
+			static constexpr clock_type::duration OneSecond = std::chrono::seconds{ 1 };
+
+			/// @brief 目標フレームレート（FPS）
+			double m_fps;
+
+			/// @brief 1フレームあたりの時間
+			clock_type::duration m_oneFrameDuration;
+
+			/// @brief 目標sleep時刻
+			clock_type::time_point m_sleepUntil;
+			
+			/// @brief フレームレートから1フレームあたりの時間の長さを計算します。
+			/// @param fps フレームレート（FPS）
+			/// @return 1フレームあたりの時間の長さ
+			/// @throw Error fps が無効な値の場合
+			SIV3D_NODISCARD_CXX20
+			static clock_type::duration FPSToOneFrameDuration(double fps);
+		};
+
+		/// @brief フレームレート制限
+		/// @remark フレームレート制限が無効の場合は nullptr
+		std::unique_ptr<Limiter> m_limiter;
+	};
+}

--- a/Siv3D/src/Siv3D/FrameRateLimit/FrameRateLimitFactory.cpp
+++ b/Siv3D/src/Siv3D/FrameRateLimit/FrameRateLimitFactory.cpp
@@ -1,0 +1,20 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2023 Ryo Suzuki
+//	Copyright (c) 2016-2023 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# include "CFrameRateLimit.hpp"
+
+namespace s3d
+{
+	ISiv3DFrameRateLimit* ISiv3DFrameRateLimit::Create()
+	{
+		return new CFrameRateLimit;
+	}
+}

--- a/Siv3D/src/Siv3D/FrameRateLimit/IFrameRateLimit.hpp
+++ b/Siv3D/src/Siv3D/FrameRateLimit/IFrameRateLimit.hpp
@@ -1,0 +1,32 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2023 Ryo Suzuki
+//	Copyright (c) 2016-2023 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# pragma once
+# include <Siv3D/Common.hpp>
+# include <Siv3D/Optional.hpp>
+
+namespace s3d
+{
+	class SIV3D_NOVTABLE ISiv3DFrameRateLimit
+	{
+	public:
+
+		static ISiv3DFrameRateLimit* Create();
+
+		virtual ~ISiv3DFrameRateLimit() = default;
+
+		virtual void update() = 0;
+
+		virtual void setTargetFrameRate(const Optional<double>& fps) = 0;
+
+		virtual Optional<double> getTargetFrameRate() const = 0;
+	};
+}

--- a/Siv3D/src/Siv3D/FrameRateLimit/SivFrameRateLimit.cpp
+++ b/Siv3D/src/Siv3D/FrameRateLimit/SivFrameRateLimit.cpp
@@ -1,0 +1,107 @@
+﻿//-----------------------------------------------
+//
+//	This file is part of the Siv3D Engine.
+//
+//	Copyright (c) 2008-2023 Ryo Suzuki
+//	Copyright (c) 2016-2023 OpenSiv3D Project
+//
+//	Licensed under the MIT License.
+//
+//-----------------------------------------------
+
+# include "CFrameRateLimit.hpp"
+# include "Siv3D/Graphics.hpp"
+# include "Siv3D/Error.hpp"
+# include "Siv3D/Duration.hpp"
+
+namespace s3d
+{
+	void CFrameRateLimit::update()
+	{
+		if (Graphics::IsVSyncEnabled())
+		{
+			// VSync が有効の場合はフレームレート制限を無視
+			return;
+		}
+
+		if (not m_limiter)
+		{
+			// フレームレート制限が無効の場合は何もしない
+			return;
+		}
+
+		m_limiter->doSleep();
+	}
+
+	void CFrameRateLimit::setTargetFrameRate(const Optional<double>& fps)
+	{
+		if (not fps)
+		{
+			// フレームレート制限を無効化
+			m_limiter.reset();
+			return;
+		}
+
+		if (m_limiter)
+		{
+			// 既にフレームレート制限が有効の場合は目標フレームレートを設定
+			m_limiter->setTargetFrameRate(*fps);
+		}
+		else
+		{
+			// フレームレート制限を有効化
+			m_limiter = std::make_unique<Limiter>(*fps);
+		}
+	}
+
+	Optional<double> CFrameRateLimit::getTargetFrameRate() const
+	{
+		if (m_limiter)
+		{
+			return m_limiter->getTargetFrameRate();
+		}
+		else
+		{
+			return none;
+		}
+	}
+
+	CFrameRateLimit::Limiter::Limiter(double fps)
+		: m_fps(fps)
+		, m_oneFrameDuration(FPSToOneFrameDuration(fps))
+		, m_sleepUntil(clock_type::now())
+	{
+	}
+
+	void CFrameRateLimit::Limiter::doSleep()
+	{
+		const auto now = clock_type::now();
+		const auto sleepUntil = Max(m_sleepUntil + m_oneFrameDuration, now);
+
+		if (now < sleepUntil)
+		{
+			std::this_thread::sleep_until(sleepUntil);
+		}
+
+		m_sleepUntil = sleepUntil;
+	}
+
+	void CFrameRateLimit::Limiter::setTargetFrameRate(double fps)
+	{
+		m_fps = fps;
+		m_oneFrameDuration = FPSToOneFrameDuration(fps);
+
+		// setTargetFrameRate が毎フレーム呼び出された場合に sleep 時間に誤差が生じないよう,
+		// m_sleepUntil はここでは更新しない
+	}
+
+	CFrameRateLimit::clock_type::duration CFrameRateLimit::Limiter::FPSToOneFrameDuration(double fps)
+	{
+		if (fps <= 0.0)
+		{
+			throw Error{ U"FrameRateLimit::Limiter::FPSToOneFrameDuration(): Invalid fps" };
+		}
+
+		return DurationCast<clock_type::duration>(OneSecond / fps);
+	}
+}

--- a/Siv3D/src/Siv3D/Graphics/SivGraphics.cpp
+++ b/Siv3D/src/Siv3D/Graphics/SivGraphics.cpp
@@ -11,6 +11,7 @@
 
 # include <Siv3D/Graphics.hpp>
 # include <Siv3D/Renderer/IRenderer.hpp>
+# include <Siv3D/FrameRateLimit/IFrameRateLimit.hpp>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 
 namespace s3d
@@ -25,6 +26,16 @@ namespace s3d
 		bool IsVSyncEnabled()
 		{
 			return SIV3D_ENGINE(Renderer)->isVSyncEnabled();
+		}
+
+		void SetTargetFrameRate(const Optional<double>& fps)
+		{
+			SIV3D_ENGINE(FrameRateLimit)->setTargetFrameRate(fps);
+		}
+
+		Optional<double> GetTargetFrameRate()
+		{
+			return SIV3D_ENGINE(FrameRateLimit)->getTargetFrameRate();
 		}
 	}
 }

--- a/Web/CMakeLists.txt
+++ b/Web/CMakeLists.txt
@@ -341,6 +341,8 @@ set(SIV3D_INTERNAL_SOURCES
   ../Siv3D/src/Siv3D/FormatInt/SivFormatInt.cpp
   ../Siv3D/src/Siv3D/Formatter/SivFormatter.cpp
   ../Siv3D/src/Siv3D/FormatUtility/SivFormatUtility.cpp
+  ../Siv3D/src/Siv3D/FrameRateLimit/SivFrameRateLimit.cpp
+  ../Siv3D/src/Siv3D/FrameRateLimit/FrameRateLimitFactory.cpp
   ../Siv3D/src/Siv3D/Gamepad/GamepadFactory.cpp
   ../Siv3D/src/Siv3D/Gamepad/SivGamepad.cpp
   ../Siv3D/src/Siv3D/GamepadInfo/SivGamepadInfo.cpp

--- a/WindowsDesktop/Siv3D.vcxproj
+++ b/WindowsDesktop/Siv3D.vcxproj
@@ -1141,6 +1141,8 @@
     <ClInclude Include="..\Siv3D\src\Siv3D\Font\GlyphRenderer\SDFGlyphRenderer.hpp" />
     <ClInclude Include="..\Siv3D\src\Siv3D\Font\IconData.hpp" />
     <ClInclude Include="..\Siv3D\src\Siv3D\Font\IFont.hpp" />
+    <ClInclude Include="..\Siv3D\src\Siv3D\FrameRateLimit\CFrameRateLimit.hpp" />
+    <ClInclude Include="..\Siv3D\src\Siv3D\FrameRateLimit\IFrameRateLimit.hpp" />
     <ClInclude Include="..\Siv3D\src\Siv3D\FreestandingMessageBox\FreestandingMessageBox.hpp" />
     <ClInclude Include="..\Siv3D\src\Siv3D\Gamepad\GamepadState.hpp" />
     <ClInclude Include="..\Siv3D\src\Siv3D\Gamepad\IGamepad.hpp" />
@@ -2292,6 +2294,8 @@
     <ClCompile Include="..\Siv3D\src\Siv3D\FormatInt\SivFormatInt.cpp" />
     <ClCompile Include="..\Siv3D\src\Siv3D\Formatter\SivFormatter.cpp" />
     <ClCompile Include="..\Siv3D\src\Siv3D\FormatUtility\SivFormatUtility.cpp" />
+    <ClCompile Include="..\Siv3D\src\Siv3D\FrameRateLimit\FrameRateLimitFactory.cpp" />
+    <ClCompile Include="..\Siv3D\src\Siv3D\FrameRateLimit\SivFrameRateLimit.cpp" />
     <ClCompile Include="..\Siv3D\src\Siv3D\GamepadInfo\SivGamepadInfo.cpp" />
     <ClCompile Include="..\Siv3D\src\Siv3D\Gamepad\GamepadFactory.cpp" />
     <ClCompile Include="..\Siv3D\src\Siv3D\Gamepad\SivGamepad.cpp" />

--- a/WindowsDesktop/Siv3D.vcxproj.filters
+++ b/WindowsDesktop/Siv3D.vcxproj.filters
@@ -1738,6 +1738,9 @@
     <Filter Include="include\Siv3D\OpenAI">
       <UniqueIdentifier>{37ac6af4-6c9f-4772-9dee-c6f5ebe74b61}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\Siv3D\FrameRateLimit">
+      <UniqueIdentifier>{4c2ac354-f8e6-466f-a4b0-8c3a7d382331}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Siv3D\include\Siv3D.hpp">
@@ -7842,6 +7845,12 @@
     <ClInclude Include="..\Siv3D\src\Siv3D\Shader\EngineShader.hpp">
       <Filter>src\Siv3D\Shader</Filter>
     </ClInclude>
+    <ClInclude Include="..\Siv3D\src\Siv3D\FrameRateLimit\CFrameRateLimit.hpp">
+      <Filter>src\Siv3D\FrameRateLimit</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Siv3D\src\Siv3D\FrameRateLimit\IFrameRateLimit.hpp">
+      <Filter>src\Siv3D\FrameRateLimit</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Siv3D\src\Siv3D\Common\Siv3DEngine.cpp">
@@ -11284,6 +11293,12 @@
     </ClCompile>
     <ClCompile Include="..\Siv3D\src\Siv3D\OpenAI\SivOpenAIVision.cpp">
       <Filter>src\Siv3D\OpenAI</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Siv3D\src\Siv3D\FrameRateLimit\FrameRateLimitFactory.cpp">
+      <Filter>src\Siv3D\FrameRateLimit</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Siv3D\src\Siv3D\FrameRateLimit\SivFrameRateLimit.cpp">
+      <Filter>src\Siv3D\FrameRateLimit</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
下記Issueについて実装しました。

https://github.com/Siv3D/OpenSiv3D/issues/1180

実装にあたって気になっている点は下記2点です。

1. 目標フレームレート(fps引数)にゼロや負の値を指定した時に例外を投げているのは問題ないか？
2. 目標フレームレート(fps引数)にNaNや+inf、-infを指定した場合も例外を投げるべきか？
補足事項として、[Qiita記事](https://qiita.com/m4saka/items/5da6cd4b57bc894d35dd)での実装ではMaxDrift(=10ミリ秒)という定数値を導入していましたが、now < sleepUntilの場合のみsleepを実行することで不要になったので、今回の実装には入っていません。

手元では現状Windows版のみで動作確認しているので、macOS版、Linux版、Web版でも正常動作するかどうかは今後確認予定です。
(Xcodeプロジェクトへのソースファイル追加についても現状は未対応です)

下記の残作業が完了したらDraft PR→PRに変更予定です。
- Xcodeプロジェクトのソースファイル一覧更新
- コメントアウトで残っている旧SetTargetFrameRateHz用のコードの削除