### PR TITLE
BMPDecoder の全ビット深度対応と、それにあたっての修正

### DIFF
--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -117,6 +117,11 @@ namespace s3d
 			reader.read(palette, paletteOwner.size());
 		}
 
+		if (header.bfOffBits > (sizeof(header) + paletteOwner.size()))
+		{
+			reader.setPos(header.bfOffBits);
+		}
+
 		Image image(width, height);
 
 		LOG_VERBOSE(U"BMPHeader::biBitCount: {}"_fmt(header.biBitCount));

--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -333,6 +333,11 @@ namespace s3d
 
 				break;
 			}
+		default:
+			{
+				LOG_FAIL(U"❌ BMPDecoder::decode(): BMPHeader::biBitCount is invalid");
+				return{};
+			}
 		}
 
 		LOG_VERBOSE(U"Image ({}x{}) decoded"_fmt(

--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -122,34 +122,32 @@ namespace s3d
 				const uint32 rowSize = width + (width % 4 ? 4 - width % 4 : 0);
 				const int32 lineStep = reverse ? -width : width;
 				Color* pDstLine = image[reverse ? height - 1 : 0];
-				
-				if (uint8* const buffer = static_cast<uint8*>(std::malloc(rowSize * 4)))
+
+				Array<uint8> bufferOwner(rowSize * 4);
+				const auto buffer = bufferOwner.data();
+
+				for (int32 y = 0; y < height; ++y)
 				{
-					for (int32 y = 0; y < height; ++y)
+					if (height - y < 4)
 					{
-						if (height - y < 4)
-						{
-							reader.read(buffer, rowSize * (height - y));
-						}
-						else if (y % 4 == 0)
-						{
-							reader.read(buffer, rowSize * 4);
-						}
-
-						uint8* tmp = &buffer[rowSize * (y % 4)];
-						const Color* const pDstEnd = pDstLine + width;
-
-						for (Color* pDst = pDstLine; pDst != pDstEnd; ++pDst)
-						{
-							const uint8* src = palette + (static_cast<size_t>(*tmp++) << 2);
-
-							pDst->set(src[2], src[1], src[0]);
-						}
-
-						pDstLine += lineStep;
+						reader.read(buffer, rowSize * (height - y));
+					}
+					else if (y % 4 == 0)
+					{
+						reader.read(buffer, rowSize * 4);
 					}
 
-					std::free(buffer);
+					uint8* tmp = &buffer[rowSize * (y % 4)];
+					const Color* const pDstEnd = pDstLine + width;
+
+					for (Color* pDst = pDstLine; pDst != pDstEnd; ++pDst)
+					{
+						const uint8* src = palette + (static_cast<size_t>(*tmp++) << 2);
+
+						pDst->set(src[2], src[1], src[0]);
+					}
+
+					pDstLine += lineStep;
 				}
 
 				break;
@@ -162,33 +160,31 @@ namespace s3d
 				const int32 lineStep = reverse ? -width : width;
 				Color* pDstLine = image[reverse ? height - 1 : 0];
 
-				if (uint8 * const buffer = static_cast<uint8*>(std::malloc(rowSize * 4)))
+				Array<uint8> bufferOwner(rowSize * 4);
+				const auto buffer = bufferOwner.data();
+
+				for (int32 y = 0; y < height; ++y)
 				{
-					for (int32 y = 0; y < height; ++y)
+					if (height - y < 4)
 					{
-						if (height - y < 4)
-						{
-							reader.read(buffer, rowSize * (height - y));
-						}
-						else if (y % 4 == 0)
-						{
-							reader.read(buffer, rowSize * 4);
-						}
-
-						const Color* const pDstEnd = pDstLine + width;
-						uint8* pSrc = &buffer[rowSize * (y % 4)];
-
-						for (Color* pDst = pDstLine; pDst != pDstEnd; ++pDst)
-						{
-							pDst->set(pSrc[2], pSrc[1], pSrc[0]);
-
-							pSrc += depthBytes;
-						}
-
-						pDstLine += lineStep;
+						reader.read(buffer, rowSize * (height - y));
+					}
+					else if (y % 4 == 0)
+					{
+						reader.read(buffer, rowSize * 4);
 					}
 
-					std::free(buffer);
+					const Color* const pDstEnd = pDstLine + width;
+					uint8* pSrc = &buffer[rowSize * (y % 4)];
+
+					for (Color* pDst = pDstLine; pDst != pDstEnd; ++pDst)
+					{
+						pDst->set(pSrc[2], pSrc[1], pSrc[0]);
+
+						pSrc += depthBytes;
+					}
+
+					pDstLine += lineStep;
 				}
 
 				break;

--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -256,6 +256,46 @@ namespace s3d
 
 				break;
 			}
+		case 16:
+			{
+				const size_t rowSize16 = ((width + 1) / 2 * 2);
+				const size_t rowSize = (rowSize16 * 2);
+				const int32 lineStep = reverse ? -width : width;
+				Color* pDstLine = image[reverse ? height - 1 : 0];
+
+				Array<uint16> bufferOwner(rowSize16 * 4);
+				const auto buffer = bufferOwner.data();
+
+				for (int32 y = 0; y < height; ++y)
+				{
+					if (height - y < 4)
+					{
+						reader.read(buffer, rowSize * (height - y));
+					}
+					else if (y % 4 == 0)
+					{
+						reader.read(buffer, rowSize * 4);
+					}
+
+					const Color* const pDstEnd = pDstLine + width;
+					uint16* pSrc = &buffer[rowSize16 * (y % 4)];
+
+					for (Color* pDst = pDstLine; pDst != pDstEnd; ++pDst)
+					{
+						uint32 b = ((*pSrc & 0x001f) << 3);
+						uint32 g = ((*pSrc & 0x07e0) >> 2);
+						uint32 r = ((*pSrc & 0xf800) >> 7);
+
+						pDst->set(r, g, b);
+
+						++pSrc;
+					}
+
+					pDstLine += lineStep;
+				}
+
+				break;
+			}
 		case 24:
 		case 32:
 			{

--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -56,7 +56,7 @@ namespace s3d
 		}
 
 		const Size size(header.biWidth, std::abs(header.biHeight));
-		
+
 		ImagePixelFormat pixelFormat = ImagePixelFormat::R8G8B8;
 
 		if (header.biBitCount == 32)
@@ -77,7 +77,7 @@ namespace s3d
 		LOG_SCOPED_TRACE(U"BMPDecoder::decode()");
 
 		BMPHeader header;
-			
+
 		if (not reader.read(header))
 		{
 			LOG_FAIL(U"❌ BMPDecoder::decode(): Failed to read header");
@@ -299,7 +299,7 @@ namespace s3d
 		case 24:
 		case 32:
 			{
-				const size_t rowSize = depth == 24 ? width * 3 + width % 4 : width * 4;			
+				const size_t rowSize = depth == 24 ? width * 3 + width % 4 : width * 4;
 				const int32 depthBytes = depth / 8;
 				const int32 lineStep = reverse ? -width : width;
 				Color* pDstLine = image[reverse ? height - 1 : 0];

--- a/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
+++ b/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp
@@ -108,6 +108,15 @@ namespace s3d
 			return{};
 		}
 
+		const uint32 paletteSize = ((header.biBitCount > 8) ? 0 : (header.biClrUsed == 0) ? (1 << header.biBitCount) : header.biClrUsed);
+		Array<uint8> paletteOwner(paletteSize * 4);
+		const auto palette = paletteOwner.data();
+
+		if (paletteSize)
+		{
+			reader.read(palette, paletteOwner.size());
+		}
+
 		Image image(width, height);
 
 		LOG_VERBOSE(U"BMPHeader::biBitCount: {}"_fmt(header.biBitCount));
@@ -116,9 +125,6 @@ namespace s3d
 		{
 		case 8:
 			{
-				uint8 palette[1024];			
-				reader.read(palette);
-
 				const uint32 rowSize = width + (width % 4 ? 4 - width % 4 : 0);
 				const int32 lineStep = reverse ? -width : width;
 				Color* pDstLine = image[reverse ? height - 1 : 0];


### PR DESCRIPTION
#1204 の実装です。

`BMPDecoder` を 1 bit 、4 bit 、および 16 bit のビット深度を持つ BMP に対応させ、すべてのビット深度に対応するようにしました。
それにあたっていくつかの修正、変更を加えました。

各コミットについて、以下で説明します。

### [バッファの確保に Array を使うよう変更](https://github.com/Siv3D/OpenSiv3D/commit/b96f057b32abc73c2524d2243cbee42dee5c89f4)

従来の実装では、バッファの確保に失敗した際に透明な画像を返すようになっています。
これは、よく使われている失敗時に空の `Image` を返すという仕様と一貫性がなく、また、そもそも `std::malloc()` を使用するのはナンセンスです。
そのため、バッファの確保に `Array` を使用するよう変更しました。

### [パレット用領域を色数に合わせて動的確保するよう変更](https://github.com/Siv3D/OpenSiv3D/commit/33b5a315b3e7154941d64c6d8613d88ff189c761)

従来の実装では、8-bit BMP を読み込む際にパレットの色数を 256 色（最大）として領域をスタックに用意し、パレットデータを読み込んでいます。
しかし、実際には `BMPHeader::biClrUsed` の値によってパレットの色数は変化するため、常に 256 色読み込もうとすると、色数が 256 色より少ないときに画像データ領域を誤ってパレットデータとして読んでしまうことになります。
そのため、パレット用領域を `BMPHeader::biClrUsed` などの関連するヘッダの値によって決まる色数の分だけ `Array` 動的確保し、指定された分だけ読み込むよう修正しました。

### [BMPHeader::bfOffBits を参照するよう変更](https://github.com/Siv3D/OpenSiv3D/commit/941e33e7235bc192b1a91f8829dbedaa0b009953)

従来の実装では、ヘッダ、パレットデータのすぐ後から画像データを読み込んでいます。
しかし、BMP 画像ファイルではヘッダ、パレットデータの後に追加情報や意味のない領域が挟まることがあります。
実際の画像データの開始位置は `BMPHeader::bfOffBits` により示されます。
そのため、ヘッダ、パレットデータを読み込んだ後のファイルの読み込み位置が `BMPHeader::bfOffBits` より小さいとき、`BMPHeader::bfOffBits` まで読み込み位置を変更するよう修正しました。

### [1-bit, 4-bit BMP に対応](https://github.com/Siv3D/OpenSiv3D/commit/799394437366029af75efb3f79dfd2ff61931e7e)

1-bit, 4-bit BMP に対応しました。

### [16-bit BMP に対応](https://github.com/Siv3D/OpenSiv3D/commit/13d8a665107e57650e579a234fe95c6b3adbe886)

16-bit BMP に対応しました。
16-bit BMP は R5G5B5 形式と R5G6B5 形式がありますが、R5G5B5 形式にのみ対応しています。
R5G6B5 形式は従来の実装と同様に以下に示す条件分岐によってはじかれます。

https://github.com/Siv3D/OpenSiv3D/blob/33ec9281b6968592a6835ec1772d7571fc94228f/Siv3D/src/Siv3D/ImageFormat/BMP/BMPDecoder.cpp?ts=4#L93-L97

### [不正なビット深度に対して失敗ログを出すよう変更](https://github.com/Siv3D/OpenSiv3D/commit/2e740e7c794abc84f6f115f4217d1f1ffe631ad2)

不正なビット深度の BMP を読み込んだとき、失敗ログを出力して空の `Image` を返すよう変更しました。
このコードに到達した際、既に確保した `Image` が無駄になりますが、滅多にないことなので目をつぶりました。

### [末尾の空白を削除](https://github.com/Siv3D/OpenSiv3D/commit/ea319f499281a24c1a316fcb0ffa76220d12e243)

気になったので、末尾の空白を削除しました。
