### PR TITLE
LineString の .calculateBuffer(), .calculateRoundBuffer() を1頂点に対応 #1209

### DIFF
--- a/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
+++ b/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
@@ -1290,7 +1290,7 @@ namespace s3d
 
 		Polygon CalculateRoundBuffer(const LineString& points, const double distance, CloseRing closeRing, int32 bufferQuality)
 		{
-			if (points.size() < 2)
+			if (points.size() < 1)
 			{
 				return{};
 			}

--- a/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
+++ b/Siv3D/src/Siv3D/Polygon/PolygonDetail.cpp
@@ -1210,7 +1210,7 @@ namespace s3d
 	{
 		Polygon CalculateBuffer(const LineString& points, const double distance, CloseRing closeRing, int32 bufferQuality)
 		{
-			if (points.size() < 2)
+			if (points.isEmpty())
 			{
 				return{};
 			}
@@ -1290,7 +1290,7 @@ namespace s3d
 
 		Polygon CalculateRoundBuffer(const LineString& points, const double distance, CloseRing closeRing, int32 bufferQuality)
 		{
-			if (points.size() < 1)
+			if (points.isEmpty())
 			{
 				return{};
 			}


### PR DESCRIPTION
#1209 の実装です。
