### PR TITLE
AsyncTask 関連のテンプレートパラメータ制約を修正

### DIFF
--- a/Siv3D/include/Siv3D/AsyncTask.hpp
+++ b/Siv3D/include/Siv3D/AsyncTask.hpp
@@ -45,7 +45,7 @@ namespace s3d
 		/// @param ...args 非同期処理のタスクで実行する関数の引数
 		/// @remark 作成と同時にタスクが非同期で実行されます。
 		/// @remark 参照を渡す場合は `std::ref()` を使ってください。
-		template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<Fty, Args...>>* = nullptr>
+		template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<std::decay_t<Fty>, std::decay_t<Args>...>>* = nullptr>
 		SIV3D_NODISCARD_CXX20
 		explicit AsyncTask(Fty&& f, Args&&... args);
 
@@ -97,7 +97,7 @@ namespace s3d
 		base_type m_data;
 	};
 
-	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<Fty, Args...>>* = nullptr>
+	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<std::decay_t<Fty>, std::decay_t<Args>...>>* = nullptr>
 	AsyncTask(Fty, Args...)->AsyncTask<std::invoke_result_t<std::decay_t<Fty>, std::decay_t<Args>...>>;
 
 	/// @brief 非同期処理のタスクを作成します。
@@ -108,7 +108,7 @@ namespace s3d
 	/// @remark 作成と同時にタスクが非同期で実行されます。
 	/// @remark 参照を渡す場合は `std::ref()` を使ってください。
 	/// @return 作成された非同期処理のタスク
-	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<Fty, Args...>>* = nullptr>
+	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<std::decay_t<Fty>, std::decay_t<Args>...>>* = nullptr>
 	[[nodiscard]]
 	inline auto Async(Fty&& f, Args&&... args);
 }

--- a/Siv3D/include/Siv3D/detail/AsyncTask.ipp
+++ b/Siv3D/include/Siv3D/detail/AsyncTask.ipp
@@ -22,7 +22,7 @@ namespace s3d
 		: m_data{ std::move(other.m_data) } {}
 
 	template <class Type>
-	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<Fty, Args...>>*>
+	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<std::decay_t<Fty>, std::decay_t<Args>...>>*>
 	inline AsyncTask<Type>::AsyncTask(Fty&& f, Args&&... args)
 	# if !SIV3D_PLATFORM(WEB) || defined(__EMSCRIPTEN_PTHREADS__)
 		: m_data{ std::async(std::launch::async, std::forward<Fty>(f), std::forward<Args>(args)...) } {}
@@ -91,7 +91,7 @@ namespace s3d
 		return m_data.share();
 	}
 
-	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<Fty, Args...>>*>
+	template <class Fty, class... Args, std::enable_if_t<std::is_invocable_v<std::decay_t<Fty>, std::decay_t<Args>...>>*>
 	inline auto Async(Fty&& f, Args&&... args)
 	{
 		return AsyncTask<std::invoke_result_t<std::decay_t<Fty>, std::decay_t<Args>...>>{ std::forward<Fty>(f), std::forward<Args>(args)... };


### PR DESCRIPTION
`AsyncTask` のコンストラクタテンプレートや推論補助、ヘルパ関数テンプレートのテンプレートパラメータ制約に `std::decay_t` がついておらず、オーバーロード解決に失敗することがあったので、修正しました。

**失敗するコード**

```c++
# include <Siv3D.hpp> // OpenSiv3D v0.6.14

struct Func
{
	int32 operator()(int32 x) const
	{
		return 0;
	}

	int64 operator()(int32& x) const
	{
		return 0;
	}
};

void Main()
{
	int32 x = 0;
	AsyncTask task(Func{}, x);
}
```
