### PR TITLE
2D 物理演算で三角形・四角形・ポリゴン・線分などの形状のセンサーを作れるように変更

### DIFF
--- a/Linux/App/example/script/piano.as
+++ b/Linux/App/example/script/piano.as
@@ -41,7 +41,7 @@ void Main()
 		{
 			if (keys[i].down())
 			{
-				sounds[i].playOneShot(0, 0.5);
+				sounds[i].playOneShot(0.5);
 			}
 		}
 

--- a/Siv3D/include/Siv3D/Physics2D/P2Body.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Body.hpp
@@ -59,6 +59,13 @@ namespace s3d
 		/// @return *this
 		P2Body& addLine(const Line& localPos, OneSided oneSided, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 線分のセンサー部品を物体に追加します。
+		/// @remark `P2Line` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addLineSensor(const Line& localPos, const P2Filter& filter = {});
+
 		/// @brief 連続する複数の線分の部品を物体に追加します。
 		/// @remark `P2LineString` の部品を物体に追加します。
 		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
@@ -68,6 +75,13 @@ namespace s3d
 		/// @return *this
 		P2Body& addLineString(const LineString& localPos, OneSided oneSided, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 連続する複数の線分のセンサー部品を物体に追加します。
+		/// @remark `P2LineString` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addLineStringSensor(const LineString& localPos, const P2Filter& filter = {});
+
 		/// @brief 連続する複数の線分（終点と始点を結ぶ）の部品を物体に追加します。
 		/// @remark `P2LineString` の部品を物体に追加します。
 		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
@@ -76,6 +90,13 @@ namespace s3d
 		/// @param filter 部品の干渉フィルタ
 		/// @return *this
 		P2Body& addClosedLineString(const LineString& localPos, OneSided oneSided, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 連続する複数の線分（終点と始点を結ぶ）のセンサー部品を物体に追加します。
+		/// @remark `P2LineString` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addClosedLineStringSensor(const LineString& localPos, const P2Filter& filter = {});
 
 		/// @brief 円の部品を物体に追加します。
 		/// @remark `P2Circle` の部品を物体に追加します。
@@ -100,6 +121,13 @@ namespace s3d
 		/// @return *this
 		P2Body& addRect(const RectF& localPos, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 長方形のセンサー部品を物体に追加します。
+		/// @remark `P2Rect` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addRectSensor(const RectF& localPos, const P2Filter& filter = {});
+
 		/// @brief 三角形の部品を物体に追加します。
 		/// @remark `P2Triangle` の部品を物体に追加します。
 		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
@@ -107,6 +135,13 @@ namespace s3d
 		/// @param filter 部品の干渉フィルタ
 		/// @return *this
 		P2Body& addTriangle(const Triangle& localPos, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 三角形のセンサー部品を物体に追加します。
+		/// @remark `P2Triangle` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addTriangleSensor(const Triangle& localPos, const P2Filter& filter = {});
 
 		/// @brief 凸な四角形の部品を物体に追加します。
 		/// @remark `P2Quad` の部品を物体に追加します。
@@ -116,6 +151,13 @@ namespace s3d
 		/// @return *this
 		P2Body& addQuad(const Quad& localPos, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 凸な四角形のセンサー部品を物体に追加します。
+		/// @remark `P2Quad` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addQuadSensor(const Quad& localPos, const P2Filter& filter = {});
+
 		/// @brief 多角形の部品を物体に追加します。
 		/// @remark `P2Polygon` の部品を物体に追加します。
 		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
@@ -123,6 +165,13 @@ namespace s3d
 		/// @param filter 部品の干渉フィルタ
 		/// @return *this
 		P2Body& addPolygon(const Polygon& localPos, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 多角形のセンサー部品を物体に追加します。
+		/// @remark `P2Polygon` の部品を物体に追加します。
+		/// @param localPos 物体のワールド座標から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return *this
+		P2Body& addPolygonSensor(const Polygon& localPos, const P2Filter& filter = {});
 
 		/// @brief 複数の多角形の部品を物体に追加します。
 		/// @remark 複数の `P2Polygon` の部品を物体に追加します。

--- a/Siv3D/include/Siv3D/Physics2D/P2Line.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Line.hpp
@@ -23,7 +23,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2Line(b2Body& body, const Line& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter);
+		P2Line(b2Body& body, const Line& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2LineString.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2LineString.hpp
@@ -22,7 +22,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2LineString(b2Body& body, const LineString& lines, CloseRing closeRing, OneSided oneSided, const P2Material& material, const P2Filter& filter);
+		P2LineString(b2Body& body, const LineString& lines, CloseRing closeRing, OneSided oneSided, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2Polygon.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Polygon.hpp
@@ -22,7 +22,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2Polygon(b2Body& body, const Polygon& polygon, const P2Material& material, const P2Filter& filter);
+		P2Polygon(b2Body& body, const Polygon& polygon, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2Quad.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Quad.hpp
@@ -22,7 +22,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2Quad(b2Body& body, const Quad& quad, const P2Material& material, const P2Filter& filter);
+		P2Quad(b2Body& body, const Quad& quad, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2Rect.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Rect.hpp
@@ -22,7 +22,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2Rect(b2Body& body, const RectF& rect, const P2Material& material, const P2Filter& filter);
+		P2Rect(b2Body& body, const RectF& rect, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2Triangle.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2Triangle.hpp
@@ -22,7 +22,7 @@ namespace s3d
 	public:
 
 		SIV3D_NODISCARD_CXX20
-		P2Triangle(b2Body& body, const Triangle& triangle, const P2Material& material, const P2Filter& filter);
+		P2Triangle(b2Body& body, const Triangle& triangle, const P2Material& material, const P2Filter& filter, bool isSensor);
 
 		[[nodiscard]]
 		P2ShapeType getShapeType() const noexcept override;

--- a/Siv3D/include/Siv3D/Physics2D/P2World.hpp
+++ b/Siv3D/include/Siv3D/Physics2D/P2World.hpp
@@ -96,6 +96,17 @@ namespace s3d
 		[[nodiscard]]
 		P2Body createLine(P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, OneSided oneSided = OneSided::No, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 線分のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Line` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類（P2BodyType::Dynamic は指定不可）
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createLineSensor(P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, const P2Filter& filter = {});
+
 		/// @brief 連続する複数の線分を部品として持つ物体を作成します。
 		/// @remark 物体は `P2LineString` の部品を持ちます。
 		/// @param bodyType 物体の種類（P2BodyType::Dynamic は指定不可）
@@ -108,6 +119,17 @@ namespace s3d
 		[[nodiscard]]
 		P2Body createLineString(P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, OneSided oneSided = OneSided::No, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 連続する複数の線分のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2LineString` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類（P2BodyType::Dynamic は指定不可）
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createLineStringSensor(P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter = {});
+
 		/// @brief 連続する複数の線分（終点と始点を結ぶ）を部品として持つ物体を作成します。
 		/// @remark 物体は `P2LineString` の部品を持ちます。
 		/// @param bodyType 物体の種類（P2BodyType::Dynamic は指定不可）
@@ -119,6 +141,17 @@ namespace s3d
 		/// @return 作成した物体
 		[[nodiscard]]
 		P2Body createClosedLineString(P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, OneSided oneSided = OneSided::No, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 連続する複数の線分（終点と始点を結ぶ）のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2LineString` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類（P2BodyType::Dynamic は指定不可）
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createClosedLineStringSensor(P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter = {});
 
 		/// @brief 円を部品として持つ物体を作成します。
 		/// @remark 物体は `P2Circle` の部品を持ちます。
@@ -153,6 +186,17 @@ namespace s3d
 		/// @return 作成した物体
 		[[nodiscard]]
 		P2Body createCircleSensor(P2BodyType bodyType, const Vec2& worldPos, double r, const P2Filter& filter = {});
+
+		/// @brief 円形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Circle` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createCircleSensor(P2BodyType bodyType, const Vec2& worldPos, const Circle& localPos, const P2Filter& filter = {});
 
 		/// @brief 正方形を部品として持つ物体を作成します。
 		/// @remark 物体は `P2Rect` の部品を持ちます。
@@ -189,6 +233,41 @@ namespace s3d
 		[[nodiscard]]
 		P2Body createRect(P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 正方形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Rect` の部品を持ちます。
+		/// @remark 正方形の中心座標は `worldPos` です。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param size センサーの一辺の長さ (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createRectSensor(P2BodyType bodyType, const Vec2& worldPos, double size, const P2Filter& filter = {});
+
+		/// @brief 長方形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Rect` の部品を持ちます。
+		/// @remark 長方形の中心座標は `worldPos` です。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param size センサーの幅と高さ (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createRectSensor(P2BodyType bodyType, const Vec2& worldPos, const SizeF& size, const P2Filter& filter = {});
+
+		/// @brief 長方形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Rect` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createRectSensor(P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Filter& filter = {});
+
 		/// @brief 三角形を部品として持つ物体を作成します。
 		/// @remark 物体は `P2Triangle` の部品を持ちます。
 		/// @param bodyType 物体の種類
@@ -199,6 +278,17 @@ namespace s3d
 		/// @return 作成した物体
 		[[nodiscard]]
 		P2Body createTriangle(P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 三角形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Triangle` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createTriangleSensor(P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Filter& filter = {});
 
 		/// @brief 凸な四角形を部品として持つ物体を作成します。
 		/// @remark 物体は `P2Quad` の部品を持ちます。
@@ -211,6 +301,16 @@ namespace s3d
 		[[nodiscard]]
 		P2Body createQuad(P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Material& material = {}, const P2Filter& filter = {});
 
+		/// @brief 凸な四角形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Quad` の部品を持ちます。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createQuadSensor(P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Filter& filter = {});
+
 		/// @brief 多角形を部品として持つ物体を作成します。
 		/// @remark 物体は `P2Polygon` の部品を持ちます。
 		/// @param bodyType 物体の種類
@@ -221,6 +321,17 @@ namespace s3d
 		/// @return 作成した物体
 		[[nodiscard]]
 		P2Body createPolygon(P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Material& material = {}, const P2Filter& filter = {});
+
+		/// @brief 多角形のセンサー部品を持つ物体を作成します。
+		/// @remark 物体は `P2Polygon` の部品を持ちます。
+		/// @remark センサーは他の物体と干渉しませんが接触情報は発生します。
+		/// @param bodyType 物体の種類
+		/// @param worldPos 物体のワールド座標 (cm) 
+		/// @param localPos `worldPos` から見たローカルでの形状の座標 (cm) 
+		/// @param filter センサーの干渉フィルタ
+		/// @return 作成した物体
+		[[nodiscard]]
+		P2Body createPolygonSensor(P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Filter& filter = {});
 
 		/// @brief 複数の多角形を部品として持つ物体を作成します。
 		/// @remark 物体は複数の `P2Polygon` の部品を持ちます。

--- a/Siv3D/src/Siv3D/Physics2D/P2Body.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Body.cpp
@@ -61,6 +61,18 @@ namespace s3d
 		return *this;
 	}
 
+	P2Body& P2Body::addLineSensor(const Line& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		pImpl->addLineSensor(localPos, filter);
+
+		return *this;
+	}
+
 	P2Body& P2Body::addLineString(const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		if (isEmpty())
@@ -78,6 +90,23 @@ namespace s3d
 		return *this;
 	}
 
+	P2Body& P2Body::addLineStringSensor(const LineString& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		if (localPos.size() < 2)
+		{
+			return *this;
+		}
+
+		pImpl->addLineStringSensor(localPos, CloseRing::No, filter);
+
+		return *this;
+	}
+
 	P2Body& P2Body::addClosedLineString(const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		if (isEmpty())
@@ -91,6 +120,23 @@ namespace s3d
 		}
 
 		pImpl->addLineString(localPos, CloseRing::Yes, oneSided, material, filter);
+
+		return *this;
+	}
+
+	P2Body& P2Body::addClosedLineStringSensor(const LineString& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		if (localPos.size() < 2)
+		{
+			return *this;
+		}
+
+		pImpl->addLineStringSensor(localPos, CloseRing::Yes, filter);
 
 		return *this;
 	}
@@ -131,6 +177,18 @@ namespace s3d
 		return *this;
 	}
 
+	P2Body& P2Body::addRectSensor(const RectF& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		pImpl->addRectSensor(localPos, filter);
+
+		return *this;
+	}
+
 	P2Body& P2Body::addTriangle(const Triangle& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		if (isEmpty())
@@ -139,6 +197,18 @@ namespace s3d
 		}
 
 		pImpl->addTriangle(localPos, material, filter);
+
+		return *this;
+	}
+
+	P2Body& P2Body::addTriangleSensor(const Triangle& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		pImpl->addTriangleSensor(localPos, filter);
 
 		return *this;
 	}
@@ -155,6 +225,18 @@ namespace s3d
 		return *this;
 	}
 
+	P2Body& P2Body::addQuadSensor(const Quad& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		pImpl->addQuadSensor(localPos, filter);
+
+		return *this;
+	}
+
 	P2Body& P2Body::addPolygon(const Polygon& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		if (isEmpty())
@@ -163,6 +245,18 @@ namespace s3d
 		}
 
 		pImpl->addPolygon(localPos, material, filter);
+
+		return *this;
+	}
+
+	P2Body& P2Body::addPolygonSensor(const Polygon& localPos, const P2Filter& filter)
+	{
+		if (isEmpty())
+		{
+			return *this;
+		}
+
+		pImpl->addPolygonSensor(localPos, filter);
 
 		return *this;
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2BodyDetail.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2BodyDetail.cpp
@@ -58,14 +58,28 @@ namespace s3d
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2Line>(*m_body, localPos, oneSided, material, filter));
+		m_shapes.push_back(std::make_shared<P2Line>(*m_body, localPos, oneSided, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addLineSensor(const Line& localPos, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2Line>(*m_body, localPos, OneSided::No, P2Material{}, filter, true));
 	}
 
 	void P2Body::P2BodyDetail::addLineString(const LineString& localPos, const CloseRing closeRing, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2LineString>(*m_body, localPos, closeRing, oneSided, material, filter));
+		m_shapes.push_back(std::make_shared<P2LineString>(*m_body, localPos, closeRing, oneSided, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addLineStringSensor(const LineString& localPos, const CloseRing closeRing, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2LineString>(*m_body, localPos, closeRing, OneSided::No, P2Material{}, filter, true));
 	}
 
 	void P2Body::P2BodyDetail::addCircle(const Circle& localPos, const P2Material& material, const P2Filter& filter)
@@ -86,28 +100,56 @@ namespace s3d
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2Rect>(*m_body, localPos, material, filter));
+		m_shapes.push_back(std::make_shared<P2Rect>(*m_body, localPos, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addRectSensor(const RectF& localPos, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2Rect>(*m_body, localPos, P2Material{}, filter, true));
 	}
 
 	void P2Body::P2BodyDetail::addTriangle(const Triangle& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2Triangle>(*m_body, localPos, material, filter));
+		m_shapes.push_back(std::make_shared<P2Triangle>(*m_body, localPos, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addTriangleSensor(const Triangle& localPos, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2Triangle>(*m_body, localPos, P2Material{}, filter, true));
 	}
 
 	void P2Body::P2BodyDetail::addQuad(const Quad& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2Quad>(*m_body, localPos, material, filter));
+		m_shapes.push_back(std::make_shared<P2Quad>(*m_body, localPos, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addQuadSensor(const Quad& localPos, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2Quad>(*m_body, localPos, P2Material{}, filter, true));
 	}
 
 	void P2Body::P2BodyDetail::addPolygon(const Polygon& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		assert(m_body);
 
-		m_shapes.push_back(std::make_shared<P2Polygon>(*m_body, localPos, material, filter));
+		m_shapes.push_back(std::make_shared<P2Polygon>(*m_body, localPos, material, filter, false));
+	}
+
+	void P2Body::P2BodyDetail::addPolygonSensor(const Polygon& localPos, const P2Filter& filter)
+	{
+		assert(m_body);
+
+		m_shapes.push_back(std::make_shared<P2Polygon>(*m_body, localPos, P2Material{}, filter, true));
 	}
 
 	b2Body& P2Body::P2BodyDetail::getBody() noexcept

--- a/Siv3D/src/Siv3D/Physics2D/P2BodyDetail.hpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2BodyDetail.hpp
@@ -31,7 +31,11 @@ namespace s3d
 
 		void addLine(const Line& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter);
 
+		void addLineSensor(const Line& localPos, const P2Filter& filter);
+
 		void addLineString(const LineString& localPos, CloseRing closeRing, OneSided oneSided, const P2Material& material, const P2Filter& filter);
+
+		void addLineStringSensor(const LineString& localPos, CloseRing closeRing, const P2Filter& filter);
 
 		void addCircle(const Circle& localPos, const P2Material& material, const P2Filter& filter);
 
@@ -39,11 +43,19 @@ namespace s3d
 
 		void addRect(const RectF& localPos, const P2Material& material, const P2Filter& filter);
 
+		void addRectSensor(const RectF& localPos, const P2Filter& filter);
+
 		void addTriangle(const Triangle& localPos, const P2Material& material, const P2Filter& filter);
+
+		void addTriangleSensor(const Triangle& localPos, const P2Filter& filter);
 
 		void addQuad(const Quad& localPos, const P2Material& material, const P2Filter& filter);
 
+		void addQuadSensor(const Quad& localPos, const P2Filter& filter);
+
 		void addPolygon(const Polygon& polygon, const P2Material& material, const P2Filter& filter);
+
+		void addPolygonSensor(const Polygon& polygon, const P2Filter& filter);
 
 		[[nodiscard]]
 		b2Body& getBody() noexcept;

--- a/Siv3D/src/Siv3D/Physics2D/P2Line.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Line.cpp
@@ -14,7 +14,7 @@
 
 namespace s3d
 {
-	P2Line::P2Line(b2Body& body, const Line& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
+	P2Line::P2Line(b2Body& body, const Line& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter, const bool isSensor)
 		: m_pShape{ std::make_unique<b2EdgeShape>() }
 		, m_oneSided{ oneSided }
 	{
@@ -30,7 +30,7 @@ namespace s3d
 			m_pShape->SetTwoSided(p0, p1);
 		}
 
-		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter);
+		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter, isSensor);
 
 		m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2LineString.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2LineString.cpp
@@ -14,7 +14,7 @@
 
 namespace s3d
 {
-	P2LineString::P2LineString(b2Body& body, const LineString& lines, const CloseRing closeRing, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
+	P2LineString::P2LineString(b2Body& body, const LineString& lines, const CloseRing closeRing, const OneSided oneSided, const P2Material& material, const P2Filter& filter, const bool isSensor)
 		: m_pShape{ std::make_unique<b2ChainShape>() }
 		, m_lineString(lines.size())
 		, m_closeRing{ closeRing }
@@ -78,7 +78,7 @@ namespace s3d
 			}
 		}
 
-		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter);
+		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter, isSensor);
 
 		m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2Polygon.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Polygon.cpp
@@ -15,7 +15,7 @@
 
 namespace s3d
 {
-	P2Polygon::P2Polygon(b2Body& body, const Polygon& polygon, const P2Material& material, const P2Filter& filter)
+	P2Polygon::P2Polygon(b2Body& body, const Polygon& polygon, const P2Material& material, const P2Filter& filter, const bool isSensor)
 		: m_basePolygon{ polygon }
 	{
 		b2PolygonShape m_shape;
@@ -28,7 +28,7 @@ namespace s3d
 
 			m_shape.Set(points, 3);
 
-			const b2FixtureDef fixtureDef = detail::MakeFixtureDef(&m_shape, material, filter);
+			const b2FixtureDef fixtureDef = detail::MakeFixtureDef(&m_shape, material, filter, isSensor);
 
 			m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 		}

--- a/Siv3D/src/Siv3D/Physics2D/P2Quad.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Quad.cpp
@@ -14,14 +14,14 @@
 
 namespace s3d
 {
-	P2Quad::P2Quad(b2Body& body, const Quad& quad, const P2Material& material, const P2Filter& filter)
+	P2Quad::P2Quad(b2Body& body, const Quad& quad, const P2Material& material, const P2Filter& filter, bool const isSensor)
 		: m_pShape{ std::make_unique<b2PolygonShape>() }
 	{
 		const b2Vec2 points[4] = { detail::ToB2Vec2(quad.p0), detail::ToB2Vec2(quad.p1), detail::ToB2Vec2(quad.p2), detail::ToB2Vec2(quad.p3) };
 
 		m_pShape->Set(points, 4);
 
-		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter);
+		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter, isSensor);
 
 		m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2Rect.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Rect.cpp
@@ -14,12 +14,12 @@
 
 namespace s3d
 {
-	P2Rect::P2Rect(b2Body& body, const RectF& rect, const P2Material& material, const P2Filter& filter)
+	P2Rect::P2Rect(b2Body& body, const RectF& rect, const P2Material& material, const P2Filter& filter, const bool isSensor)
 		: m_pShape{ std::make_unique<b2PolygonShape>() }
 	{
 		m_pShape->SetAsBox(static_cast<float>(rect.w * 0.5), static_cast<float>(rect.h * 0.5), detail::ToB2Vec2(rect.center()), 0.0f);
 
-		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter);
+		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter, isSensor);
 
 		m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2Triangle.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2Triangle.cpp
@@ -14,14 +14,14 @@
 
 namespace s3d
 {
-	P2Triangle::P2Triangle(b2Body& body, const Triangle& triangle, const P2Material& material, const P2Filter& filter)
+	P2Triangle::P2Triangle(b2Body& body, const Triangle& triangle, const P2Material& material, const P2Filter& filter, bool const isSensor)
 		: m_pShape{ std::make_unique<b2PolygonShape>() }
 	{
 		const b2Vec2 points[3] = { detail::ToB2Vec2(triangle.p0), detail::ToB2Vec2(triangle.p1), detail::ToB2Vec2(triangle.p2) };
 
 		m_pShape->Set(points, 3);
 
-		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter);
+		const b2FixtureDef fixtureDef = detail::MakeFixtureDef(m_pShape.get(), material, filter, isSensor);
 
 		m_fixtures.push_back(body.CreateFixture(&fixtureDef));
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2World.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2World.cpp
@@ -71,6 +71,16 @@ namespace s3d
 		return pImpl->createLine(pImpl, bodyType, worldPos, localPos, oneSided, material, filter);
 	}
 
+	P2Body P2World::createLineSensor(const P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, const P2Filter& filter)
+	{
+		if (bodyType == P2BodyType::Dynamic)
+		{
+			throw Error{ U"P2World::createLine(): bodyType must be either P2BodyType::Static or P2BodyType::Kinematic" };
+		}
+
+		return pImpl->createLineSensor(pImpl, bodyType, worldPos, localPos, filter);
+	}
+
 	P2Body P2World::createLineString(const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		if (bodyType == P2BodyType::Dynamic)
@@ -81,6 +91,16 @@ namespace s3d
 		return pImpl->createLineString(pImpl, bodyType, worldPos, localPos, oneSided, material, filter);
 	}
 
+	P2Body P2World::createLineStringSensor(const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter)
+	{
+		if (bodyType == P2BodyType::Dynamic)
+		{
+			throw Error{ U"P2World::createLineString(): bodyType must be either P2BodyType::Static or P2BodyType::Kinematic" };
+		}
+
+		return pImpl->createLineStringSensor(pImpl, bodyType, worldPos, localPos, filter);
+	}
+
 	P2Body P2World::createClosedLineString(const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		if (bodyType == P2BodyType::Dynamic)
@@ -89,6 +109,16 @@ namespace s3d
 		}
 
 		return pImpl->createClosedLineString(pImpl, bodyType, worldPos, localPos, oneSided, material, filter);
+	}
+
+	P2Body P2World::createClosedLineStringSensor(const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter)
+	{
+		if (bodyType == P2BodyType::Dynamic)
+		{
+			throw Error{ U"P2World::createClosedLineString(): bodyType must be either P2BodyType::Static or P2BodyType::Kinematic" };
+		}
+
+		return pImpl->createClosedLineStringSensor(pImpl, bodyType, worldPos, localPos, filter);
 	}
 
 	P2Body P2World::createCircle(const P2BodyType bodyType, const Vec2& worldPos, const double r, const P2Material& material, const P2Filter& filter)
@@ -106,6 +136,11 @@ namespace s3d
 		return pImpl->createCircleSensor(pImpl, bodyType, worldPos, Circle{ 0, 0, r }, filter);
 	}
 
+	P2Body P2World::createCircleSensor(const P2BodyType bodyType, const Vec2& worldPos, const Circle& localPos, const P2Filter& filter)
+	{
+		return pImpl->createCircleSensor(pImpl, bodyType, worldPos, localPos, filter);
+	}
+
 	P2Body P2World::createRect(const P2BodyType bodyType, const Vec2& worldPos, const double size, const P2Material& material, const P2Filter& filter)
 	{
 		return createRect(bodyType, worldPos, RectF{ Arg::center(0, 0), size }, material, filter);
@@ -121,9 +156,29 @@ namespace s3d
 		return pImpl->createRect(pImpl, bodyType, worldPos, localPos, material, filter);
 	}
 
+	P2Body P2World::createRectSensor(const P2BodyType bodyType, const Vec2& worldPos, const double size, const P2Filter& filter)
+	{
+		return createRectSensor(bodyType, worldPos, RectF{ Arg::center(0, 0), size }, filter);
+	}
+
+	P2Body P2World::createRectSensor(const P2BodyType bodyType, const Vec2& worldPos, const SizeF& size, const P2Filter& filter)
+	{
+		return createRectSensor(bodyType, worldPos, RectF{ Arg::center(0, 0), size }, filter);
+	}
+
+	P2Body P2World::createRectSensor(const P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Filter& filter)
+	{
+		return pImpl->createRectSensor(pImpl, bodyType, worldPos, localPos, filter);
+	}
+
 	P2Body P2World::createTriangle(const P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		return pImpl->createTriangle(pImpl, bodyType, worldPos, localPos, material, filter);
+	}
+
+	P2Body P2World::createTriangleSensor(const P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Filter& filter)
+	{
+		return pImpl->createTriangleSensor(pImpl, bodyType, worldPos, localPos, filter);
 	}
 
 	P2Body P2World::createQuad(const P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Material& material, const P2Filter& filter)
@@ -131,9 +186,19 @@ namespace s3d
 		return pImpl->createQuad(pImpl, bodyType, worldPos, localPos, material, filter);
 	}
 
+	P2Body P2World::createQuadSensor(const P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Filter& filter)
+	{
+		return pImpl->createQuadSensor(pImpl, bodyType, worldPos, localPos, filter);
+	}
+
 	P2Body P2World::createPolygon(const P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		return pImpl->createPolygon(pImpl, bodyType, worldPos, localPos, material, filter);
+	}
+
+	P2Body P2World::createPolygonSensor(const P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Filter& filter)
+	{
+		return pImpl->createPolygonSensor(pImpl, bodyType, worldPos, localPos, filter);
 	}
 
 	P2Body P2World::createPolygons(const P2BodyType bodyType, const Vec2& worldPos, const MultiPolygon& localPos, const P2Material& material, const P2Filter& filter)

--- a/Siv3D/src/Siv3D/Physics2D/P2WorldDetail.cpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2WorldDetail.cpp
@@ -42,6 +42,15 @@ namespace s3d
 		return body;
 	}
 
+	P2Body detail::P2WorldDetail::createLineSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addLineSensor(localPos, filter);
+
+		return body;
+	}
+
 	P2Body detail::P2WorldDetail::createLineString(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		P2Body body{ world, generateNextID(), worldPos, bodyType };
@@ -51,11 +60,29 @@ namespace s3d
 		return body;
 	}
 
+	P2Body detail::P2WorldDetail::createLineStringSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addLineStringSensor(localPos, filter);
+
+		return body;
+	}
+
 	P2Body detail::P2WorldDetail::createClosedLineString(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const OneSided oneSided, const P2Material& material, const P2Filter& filter)
 	{
 		P2Body body{ world, generateNextID(), worldPos, bodyType };
 
 		body.addClosedLineString(localPos, oneSided, material, filter);
+
+		return body;
+	}
+
+	P2Body detail::P2WorldDetail::createClosedLineStringSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addClosedLineStringSensor(localPos, filter);
 
 		return body;
 	}
@@ -87,11 +114,29 @@ namespace s3d
 		return body;
 	}
 
+	P2Body detail::P2WorldDetail::createRectSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addRectSensor(localPos, filter);
+
+		return body;
+	}
+
 	P2Body detail::P2WorldDetail::createTriangle(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		P2Body body{ world, generateNextID(), worldPos, bodyType };
 
 		body.addTriangle(localPos, material, filter);
+
+		return body;
+	}
+
+	P2Body detail::P2WorldDetail::createTriangleSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addTriangleSensor(localPos, filter);
 
 		return body;
 	}
@@ -105,11 +150,29 @@ namespace s3d
 		return body;
 	}
 
+	P2Body detail::P2WorldDetail::createQuadSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addQuadSensor(localPos, filter);
+
+		return body;
+	}
+
 	P2Body detail::P2WorldDetail::createPolygon(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Material& material, const P2Filter& filter)
 	{
 		P2Body body{ world, generateNextID(), worldPos, bodyType };
 
 		body.addPolygon(localPos, material, filter);
+
+		return body;
+	}
+
+	P2Body detail::P2WorldDetail::createPolygonSensor(const std::shared_ptr<P2WorldDetail>& world, const P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Filter& filter)
+	{
+		P2Body body{ world, generateNextID(), worldPos, bodyType };
+
+		body.addPolygonSensor(localPos, filter);
 
 		return body;
 	}

--- a/Siv3D/src/Siv3D/Physics2D/P2WorldDetail.hpp
+++ b/Siv3D/src/Siv3D/Physics2D/P2WorldDetail.hpp
@@ -31,10 +31,19 @@ namespace s3d
 		P2Body createLine(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter);
 
 		[[nodiscard]]
+		P2Body createLineSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Line& localPos, const P2Filter& filter);
+
+		[[nodiscard]]
 		P2Body createLineString(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter);
 
 		[[nodiscard]]
+		P2Body createLineStringSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter);
+
+		[[nodiscard]]
 		P2Body createClosedLineString(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, OneSided oneSided, const P2Material& material, const P2Filter& filter);
+
+		[[nodiscard]]
+		P2Body createClosedLineStringSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const LineString& localPos, const P2Filter& filter);
 
 		[[nodiscard]]
 		P2Body createCircle(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Circle& localPos, const P2Material& material, const P2Filter& filter);
@@ -46,13 +55,25 @@ namespace s3d
 		P2Body createRect(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Material& material, const P2Filter& filter);
 
 		[[nodiscard]]
+		P2Body createRectSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const RectF& localPos, const P2Filter& filter);
+
+		[[nodiscard]]
 		P2Body createTriangle(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Material& material, const P2Filter& filter);
+
+		[[nodiscard]]
+		P2Body createTriangleSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Triangle& localPos, const P2Filter& filter);
 
 		[[nodiscard]]
 		P2Body createQuad(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Material& material, const P2Filter& filter);
 
 		[[nodiscard]]
+		P2Body createQuadSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Quad& localPos, const P2Filter& filter);
+
+		[[nodiscard]]
 		P2Body createPolygon(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Material& material, const P2Filter& filter);
+
+		[[nodiscard]]
+		P2Body createPolygonSensor(const std::shared_ptr<P2WorldDetail>& world, P2BodyType bodyType, const Vec2& worldPos, const Polygon& localPos, const P2Filter& filter);
 
 		[[nodiscard]]
 		P2PivotJoint createPivotJoint(const std::shared_ptr<P2WorldDetail>& world, const P2Body& bodyA, const P2Body& bodyB, const Vec2& worldAnchorPos, EnableCollision enableCollision);

--- a/Web/App/example/script/piano.as
+++ b/Web/App/example/script/piano.as
@@ -41,7 +41,7 @@ void Main()
 		{
 			if (keys[i].down())
 			{
-				sounds[i].playOneShot(0, 0.5);
+				sounds[i].playOneShot(0.5);
 			}
 		}
 

--- a/Web/VisualStudioTemplate/Files/example/script/piano.as
+++ b/Web/VisualStudioTemplate/Files/example/script/piano.as
@@ -41,7 +41,7 @@ void Main()
 		{
 			if (keys[i].down())
 			{
-				sounds[i].playOneShot(0, 0.5);
+				sounds[i].playOneShot(0.5);
 			}
 		}
 

--- a/WindowsDesktop/App/example/script/piano.as
+++ b/WindowsDesktop/App/example/script/piano.as
@@ -41,7 +41,7 @@ void Main()
 		{
 			if (keys[i].down())
 			{
-				sounds[i].playOneShot(0, 0.5);
+				sounds[i].playOneShot(0.5);
 			}
 		}
 

--- a/macOS/App/example/script/piano.as
+++ b/macOS/App/example/script/piano.as
@@ -41,7 +41,7 @@ void Main()
 		{
 			if (keys[i].down())
 			{
-				sounds[i].playOneShot(0, 0.5);
+				sounds[i].playOneShot(0.5);
 			}
 		}
 


### PR DESCRIPTION
2D 物理演算で円形以外の形状のセンサーを作れるように変更を加えました。

`P2Rect` や `P2Triangle` などのコンストラクタの引数に `bool isSensor` を加えています。
`P2Body` や `P2World` などに `addRectSensor()` や `createRectSensor()` などのセンサーを作る関数を加えています。
`P2World::createCircle()` にオーバーロードが 2 つ存在しているので、それに合わせて `P2World::createCircleSensor()` も新たに 1 つオーバーロードを加えました。

次のコードで動作を確認しました。
https://gist.github.com/Aikawa3311/a8bc38cc4667f5d93b3378ef402df276