### PR TITLE
フェード時間が0のときにdraw()だけが呼ばれるよう修正

### DIFF
--- a/Siv3D/include/Siv3D/detail/SceneManager.ipp
+++ b/Siv3D/include/Siv3D/detail/SceneManager.ipp
@@ -245,6 +245,7 @@ namespace s3d
 			|| (m_transitionTimeMillisec <= 0))
 		{
 			m_current->draw();
+			return;
 		}
 
 		const double elapsed = m_stopwatch.msF();


### PR DESCRIPTION
`changeScene()`でフェード時間を0に指定したときに、`draw()`が呼ばれた後に`drawFadeOut()`も呼ばれていたので修正しました。