### PR TITLE
Math::ClampAngle 追加

### DIFF
--- a/Siv3D/include/Siv3D/Math.hpp
+++ b/Siv3D/include/Siv3D/Math.hpp
@@ -1327,12 +1327,12 @@ namespace s3d
 		//
 		//////////////////////////////////////////////////
 
-		/// @brief 最小値と最大値の範囲にクランプした角度を返します。
+		/// @brief 最小角と最大角の範囲にクランプした角度を返します。
 		/// @param angle クランプする角度
-		/// @param min 範囲の最小値
-		/// @param max 範囲の最大値
+		/// @param min 範囲の最小角
+		/// @param max 範囲の最大角
 		/// @return クランプした角度
-		/// @remark angle が範囲外である場合、角度を円環的に解釈して min または max のうちより近い方の値に調整します。
+		/// @remark 角度を円環的に解釈して min または max のうちより近い方の角度に angle を調整します。
 		[[nodiscard]]
 		inline float ClampAngle(float angle, float min, float max) noexcept;
 

--- a/Siv3D/include/Siv3D/Math.hpp
+++ b/Siv3D/include/Siv3D/Math.hpp
@@ -1323,6 +1323,28 @@ namespace s3d
 
 		//////////////////////////////////////////////////
 		//
+		//	ClampAngle
+		//
+		//////////////////////////////////////////////////
+
+		/// @brief 最小値と最大値の範囲にクランプした角度を返します。
+		/// @param angle クランプする角度
+		/// @param min 範囲の最小値
+		/// @param max 範囲の最大値
+		/// @return クランプした角度
+		/// @remark angle が範囲外である場合、角度を円環的に解釈して min または max のうちより近い方の値に調整します。
+		[[nodiscard]]
+		inline float ClampAngle(float angle, float min, float max) noexcept;
+
+		[[nodiscard]]
+		inline double ClampAngle(double angle, double min, double max) noexcept;
+
+		SIV3D_CONCEPT_ARITHMETIC
+		[[nodiscard]]
+		inline double ClampAngle(Arithmetic angle, Arithmetic min, Arithmetic max) noexcept;
+
+		//////////////////////////////////////////////////
+		//
 		//	NormalizeAngle
 		//
 		//////////////////////////////////////////////////

--- a/Siv3D/include/Siv3D/Math.hpp
+++ b/Siv3D/include/Siv3D/Math.hpp
@@ -1328,11 +1328,11 @@ namespace s3d
 		//////////////////////////////////////////////////
 
 		/// @brief 最小角と最大角の範囲にクランプした角度を返します。
-		/// @param angle クランプする角度
-		/// @param min 範囲の最小角
-		/// @param max 範囲の最大角
-		/// @return クランプした角度
-		/// @remark 角度を円環的に解釈して min または max のうちより近い方の角度に angle を調整します。
+		/// @param angle クランプする角度（ラジアン）
+		/// @param min 範囲の最小角（ラジアン）
+		/// @param max 範囲の最大角（ラジアン）
+		/// @return クランプした角度（ラジアン）
+		/// @remark angle が min の方向と max の方向の間を指さない場合、より近いほうの角度を返します。
 		[[nodiscard]]
 		inline float ClampAngle(float angle, float min, float max) noexcept;
 

--- a/Siv3D/include/Siv3D/detail/Math.ipp
+++ b/Siv3D/include/Siv3D/detail/Math.ipp
@@ -1362,14 +1362,14 @@ namespace s3d
 
 		inline float ClampAngle(const float angle, const float min, float max) noexcept
 		{
-			const auto start = (min + max) * 0.5f - TwoPiF;
+			const auto start = (min + max) * 0.5f - PiF;
 			const auto floor = Floor((angle - start) / TwoPiF) * TwoPiF;
 			return Clamp(angle, min + floor, max + floor);
 		}
 
 		inline double ClampAngle(const double angle, const double min, double max) noexcept
 		{
-			const auto start = (min + max) * 0.5 - TwoPi;
+			const auto start = (min + max) * 0.5 - Pi;
 			const auto floor = Floor((angle - start) / TwoPi) * TwoPi;
 			return Clamp(angle, min + floor, max + floor);
 		}
@@ -1377,7 +1377,7 @@ namespace s3d
 		SIV3D_CONCEPT_ARITHMETIC_
 		inline double ClampAngle(Arithmetic angle, Arithmetic min, Arithmetic max) noexcept
 		{
-			const auto start = (min + max) * 0.5 - TwoPi;
+			const auto start = (min + max) * 0.5 - Pi;
 			const auto floor = Floor((angle - start) / TwoPi) * TwoPi;
 			return Clamp(angle, min + floor, max + floor);
 		}

--- a/Siv3D/include/Siv3D/detail/Math.ipp
+++ b/Siv3D/include/Siv3D/detail/Math.ipp
@@ -1356,6 +1356,34 @@ namespace s3d
 
 		//////////////////////////////////////////////////
 		//
+		//	ClampAngle
+		//
+		//////////////////////////////////////////////////
+
+		inline float ClampAngle(const float angle, const float min, float max) noexcept
+		{
+			const auto start = (min + max) * 0.5f - TwoPiF;
+			const auto floor = Floor((angle - start) / TwoPiF) * TwoPiF;
+			return Clamp(angle, min + floor, max + floor);
+		}
+
+		inline double ClampAngle(const double angle, const double min, double max) noexcept
+		{
+			const auto start = (min + max) * 0.5 - TwoPi;
+			const auto floor = Floor((angle - start) / TwoPi) * TwoPi;
+			return Clamp(angle, min + floor, max + floor);
+		}
+
+		SIV3D_CONCEPT_ARITHMETIC_
+		inline double ClampAngle(Arithmetic angle, Arithmetic min, Arithmetic max) noexcept
+		{
+			const auto start = (min + max) * 0.5 - TwoPi;
+			const auto floor = Floor((angle - start) / TwoPi) * TwoPi;
+			return Clamp(angle, min + floor, max + floor);
+		}
+
+		//////////////////////////////////////////////////
+		//
 		//	NormalizeAngle
 		//
 		//////////////////////////////////////////////////


### PR DESCRIPTION
Discord 文脈: https://discord.com/channels/443310697397354506/999983621408567326/1305003589588226211

最小値と最大値の範囲にクランプした角度を返す Math::ClampAngle を実装しました。

検索エンジンで ClampAngle を検索したとき上位に出てくる以下の実装を参考にしています。
https://gist.github.com/johnsoncodehk/2ecb0136304d4badbb92bd0c1dbd8bae

以下の Main.cpp で動作を確認できます。

```c++
# include <Siv3D.hpp> // Siv3D v0.6.15

namespace
{
	void Test_ClampAngle(double angleDeg, double minDeg, double maxDeg)
	{
		const double angleRad = ToRadians(angleDeg);
		const double minRad = ToRadians(minDeg);
		const double maxRad = ToRadians(maxDeg);

		Print << U"ClampAngle({}_deg, {}_deg, {}_deg) = {:.4f} (= {:.4f}_deg)"_fmt(
			angleDeg, minDeg, maxDeg,
			Math::ClampAngle(angleRad, minRad, maxRad),
			ToDegrees(Math::ClampAngle(angleRad, minRad, maxRad)));
	}
}

void Main()
{
	Window::Resize(1280, 720);

	Print << U"360_deg - 15_deg = {:.04f}"_fmt(360_deg - 15_deg);
	Print << U"720_deg - 15_deg = {:.04f}"_fmt(720_deg - 15_deg);

	Print << U"-----------------------------------------------";

	Test_ClampAngle(10, -15, 15);
	Test_ClampAngle(20, -15, 15);

	Print << U"-----------------------------------------------";

	Test_ClampAngle(350, -15, 15);
	Test_ClampAngle(340, -15, 15);
	Test_ClampAngle(700, -15, 15);

	while (System::Update())
	{
	}
}

```

実行結果

![image](https://github.com/user-attachments/assets/1ee37ead-bcaa-4a28-9ebd-d43010aca2d1)

