### PR TITLE
長方形内のテキスト描画でドットの間隔がフォントサイズによって変わる問題を修正

### DIFF
--- a/Siv3D/src/Siv3D/Font/GlyphCache/BitmapGlyphCache.cpp
+++ b/Siv3D/src/Siv3D/Font/GlyphCache/BitmapGlyphCache.cpp
@@ -106,12 +106,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{
@@ -220,12 +220,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{

--- a/Siv3D/src/Siv3D/Font/GlyphCache/MSDFGlyphCache.cpp
+++ b/Siv3D/src/Siv3D/Font/GlyphCache/MSDFGlyphCache.cpp
@@ -105,12 +105,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{
@@ -219,12 +219,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{

--- a/Siv3D/src/Siv3D/Font/GlyphCache/SDFGlyphCache.cpp
+++ b/Siv3D/src/Siv3D/Font/GlyphCache/SDFGlyphCache.cpp
@@ -105,12 +105,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{
@@ -219,12 +219,12 @@ namespace s3d
 		}
 		updateTexture();
 
-		const double dotXAdvance = m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance;
 		const Vec2 areaBottomRight = area.br();
 
 		const auto& prop = font.getProperty();
 		const double scale = (size / prop.fontPixelSize);
 		const double lineHeight = (prop.height() * scale * lineHeightScale);
+		const double dotXAdvance = (m_glyphTable.find(dotGlyphCluster[0].glyphIndex)->second.info.xAdvance * scale);
 
 		if ((area.w < (dotXAdvance * 3)) || (area.h < lineHeight))
 		{


### PR DESCRIPTION
- reported by: https://discord.com/channels/443310697397354506/1000291580915232879/1307180108208935023

各 GlyphCache の実装で、ドットの進み `dotXAdvance` にフォントサイズ指定による尺度 `scale` を掛けていないことが原因でしたので修正しました。

