### PR TITLE
DiscreteSample() の戻り値のコピーを回避

### DIFF
--- a/Siv3D/include/Siv3D/DiscreteDistribution.hpp
+++ b/Siv3D/include/Siv3D/DiscreteDistribution.hpp
@@ -76,27 +76,27 @@ namespace s3d
 
 	template <class Iterator, class URBG>
 	[[nodiscard]]
-	inline auto DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight, URBG&& urbg);
+	inline decltype(auto) DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight, URBG&& urbg);
 
 	template <class Iterator>
 	[[nodiscard]]
-	inline auto DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight);
+	inline decltype(auto) DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight);
 
 	template <class Container, class URBG>
 	[[nodiscard]]
-	inline auto DiscreteSample(const Container& c, DiscreteDistribution& weight, URBG&& urbg);
+	inline decltype(auto) DiscreteSample(const Container& c, DiscreteDistribution& weight, URBG&& urbg);
 
 	template <class Container>
 	[[nodiscard]]
-	inline auto DiscreteSample(const Container& c, DiscreteDistribution& weight);
+	inline decltype(auto) DiscreteSample(const Container& c, DiscreteDistribution& weight);
 
 	template <class Type, class URBG>
 	[[nodiscard]]
-	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg);
+	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg);
 	
 	template <class Type>
 	[[nodiscard]]
-	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight);
+	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight);
 }
 
 # include "detail/DiscreteDistribution.ipp"

--- a/Siv3D/include/Siv3D/DiscreteDistribution.hpp
+++ b/Siv3D/include/Siv3D/DiscreteDistribution.hpp
@@ -92,11 +92,11 @@ namespace s3d
 
 	template <class Type, class URBG>
 	[[nodiscard]]
-	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg);
+	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg);
 	
 	template <class Type>
 	[[nodiscard]]
-	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight);
+	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight);
 }
 
 # include "detail/DiscreteDistribution.ipp"

--- a/Siv3D/include/Siv3D/detail/DiscreteDistribution.ipp
+++ b/Siv3D/include/Siv3D/detail/DiscreteDistribution.ipp
@@ -73,7 +73,7 @@ namespace s3d
 	}
 
 	template <class Iterator, class URBG>
-	inline auto DiscreteSample(Iterator begin, [[maybe_unused]] Iterator end, DiscreteDistribution& weight, URBG&& urbg)
+	inline decltype(auto) DiscreteSample(Iterator begin, [[maybe_unused]] Iterator end, DiscreteDistribution& weight, URBG&& urbg)
 	{
 		assert(begin != end);
 		assert(std::distance(begin, end) == static_cast<int64>(weight.size()));
@@ -83,13 +83,13 @@ namespace s3d
 	}
 
 	template <class Iterator>
-	inline auto DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight)
+	inline decltype(auto) DiscreteSample(Iterator begin, Iterator end, DiscreteDistribution& weight)
 	{
 		return DiscreteSample(begin, end, weight, GetDefaultRNG());
 	}
 
 	template <class Container, class URBG>
-	inline auto DiscreteSample(const Container& c, DiscreteDistribution& weight, URBG&& urbg)
+	inline decltype(auto) DiscreteSample(const Container& c, DiscreteDistribution& weight, URBG&& urbg)
 	{
 		assert(std::size(c) != 0);
 		assert(std::size(c) == weight.size());
@@ -100,20 +100,20 @@ namespace s3d
 	}
 
 	template <class Container>
-	inline auto DiscreteSample(const Container& c, DiscreteDistribution& weight)
+	inline decltype(auto) DiscreteSample(const Container& c, DiscreteDistribution& weight)
 	{
 		return DiscreteSample(c, weight, GetDefaultRNG());
 	}
 
 	template <class Type, class URBG>
-	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg)
+	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg)
 	{
 		assert(ilist.size() != 0);
 		return *(ilist.begin() + weight(std::forward<URBG>(urbg)));
 	}
 
 	template <class Type>
-	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight)
+	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight)
 	{
 		return DiscreteSample(ilist, weight, GetDefaultRNG());
 	}

--- a/Siv3D/include/Siv3D/detail/DiscreteDistribution.ipp
+++ b/Siv3D/include/Siv3D/detail/DiscreteDistribution.ipp
@@ -106,14 +106,14 @@ namespace s3d
 	}
 
 	template <class Type, class URBG>
-	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg)
+	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight, URBG&& urbg)
 	{
 		assert(ilist.size() != 0);
 		return *(ilist.begin() + weight(std::forward<URBG>(urbg)));
 	}
 
 	template <class Type>
-	inline decltype(auto) DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight)
+	inline auto DiscreteSample(std::initializer_list<Type> ilist, DiscreteDistribution& weight)
 	{
 		return DiscreteSample(ilist, weight, GetDefaultRNG());
 	}


### PR DESCRIPTION
`DiscreteSample()` の戻り値の型を `auto` から `decltype(auto)` に変更することで参照型（場合によってはプロキシ型など）を返すようにし、戻り値が無駄にコピーされることを回避しました。
