### PR TITLE
Rect及びRectFクラスの関数stretchedに一つのパラメータだけ指定するオーバーロードを追加

### DIFF
--- a/Siv3D/include/Siv3D/Rect.hpp
+++ b/Siv3D/include/Siv3D/Rect.hpp
@@ -524,6 +524,30 @@ namespace s3d
 		[[nodiscard]]
 		constexpr Rect stretched(value_type top, value_type right, value_type bottom, value_type left) const noexcept;
 
+		/// @brief 上方向に拡大縮小した長方形を返します。
+		/// @param top 上方向の拡大縮小量
+		/// @return 上方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr Rect stretched(Arg::top_<value_type> top) const noexcept;
+
+		/// @brief 右方向に拡大縮小した長方形を返します。
+		/// @param right 右方向の拡大縮小量
+		/// @return 右方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr Rect stretched(Arg::right_<value_type> right) const noexcept;
+
+		/// @brief 下方向に拡大縮小した長方形を返します。
+		/// @param bottom 下方向の拡大縮小量
+		/// @return 下方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr Rect stretched(Arg::bottom_<value_type> bottom) const noexcept;
+
+		/// @brief 左方向に拡大縮小した長方形を返します。
+		/// @param left 左方向の拡大縮小量
+		/// @return 左方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr Rect stretched(Arg::left_<value_type> left) const noexcept;
+
 		[[nodiscard]]
 		constexpr RectF scaled(double s) const noexcept;
 

--- a/Siv3D/include/Siv3D/RectF.hpp
+++ b/Siv3D/include/Siv3D/RectF.hpp
@@ -576,6 +576,30 @@ namespace s3d
 		[[nodiscard]]
 		constexpr RectF stretched(value_type top, value_type right, value_type bottom, value_type left) const noexcept;
 
+		/// @brief 上方向に拡大縮小した長方形を返します。
+		/// @param top 上方向の拡大縮小量
+		/// @return 上方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr RectF stretched(Arg::top_<value_type> top) const noexcept;
+
+		/// @brief 右方向に拡大縮小した長方形を返します。
+		/// @param right 右方向の拡大縮小量
+		/// @return 右方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr RectF stretched(Arg::right_<value_type> right) const noexcept;
+
+		/// @brief 下方向に拡大縮小した長方形を返します。
+		/// @param bottom 下方向の拡大縮小量
+		/// @return 下方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr RectF stretched(Arg::bottom_<value_type> bottom) const noexcept;
+
+		/// @brief 左方向に拡大縮小した長方形を返します。
+		/// @param left 左方向の拡大縮小量
+		/// @return 左方向に拡大縮小した長方形
+		[[nodiscard]]
+		constexpr RectF stretched(Arg::left_<value_type> left) const noexcept;
+
 		[[nodiscard]]
 		constexpr RectF scaled(double s) const noexcept;
 

--- a/Siv3D/include/Siv3D/detail/Rect.ipp
+++ b/Siv3D/include/Siv3D/detail/Rect.ipp
@@ -586,6 +586,26 @@ namespace s3d
 		return{ (pos.x - left), (pos.y - top), (size.x + left + right), (size.y + top + bottom) };
 	}
 
+	inline constexpr Rect Rect::stretched(Arg::top_<value_type> top) const noexcept
+	{
+		return stretched(top.value(), 0, 0, 0);
+	}
+
+	inline constexpr Rect Rect::stretched(Arg::right_<value_type> right) const noexcept
+	{
+		return stretched(0, right.value(), 0, 0);
+	}
+
+	inline constexpr Rect Rect::stretched(Arg::bottom_<value_type> bottom) const noexcept
+	{
+		return stretched(0, 0, bottom.value(), 0);
+	}
+
+	inline constexpr Rect Rect::stretched(Arg::left_<value_type> left) const noexcept
+	{
+		return stretched(0, 0, 0, left.value());
+	}
+
 	inline constexpr RectF Rect::scaled(const double s) const noexcept
 	{
 		return{ Arg::center((pos.x + size.x * 0.5), (pos.y + size.y * 0.5)), (size.x * s), (size.y * s) };

--- a/Siv3D/include/Siv3D/detail/RectF.ipp
+++ b/Siv3D/include/Siv3D/detail/RectF.ipp
@@ -642,6 +642,26 @@ namespace s3d
 		return{ (pos.x - left), (pos.y - top), (size.x + left + right), (size.y + top + bottom) };
 	}
 
+	inline constexpr RectF RectF::stretched(Arg::top_<value_type> top) const noexcept
+	{
+		return stretched(top.value(), 0, 0, 0);
+	}
+
+	inline constexpr RectF RectF::stretched(Arg::right_<value_type> right) const noexcept
+	{
+		return stretched(0, right.value(), 0, 0);
+	}
+
+	inline constexpr RectF RectF::stretched(Arg::bottom_<value_type> bottom) const noexcept
+	{
+		return stretched(0, 0, bottom.value(), 0);
+	}
+
+	inline constexpr RectF RectF::stretched(Arg::left_<value_type> left) const noexcept
+	{
+		return stretched(0, 0, 0, left.value());
+	}
+
 	inline constexpr RectF RectF::scaled(const double s) const noexcept
 	{
 		return{ Arg::center((pos.x + size.x * 0.5), (pos.y + size.y * 0.5)), (size.x * s), (size.y * s) };


### PR DESCRIPTION
### Add directional overloads for `Rect::stretched` and `RectF::stretched`
This PR addresses [Issue #1277](https://github.com/Siv3D/OpenSiv3D/issues/1277).

[Discordサーバーで提案されていた](https://discord.com/channels/443310697397354506/999983621408567326/1314107994950078504)とおり、`Rect` および `RectF` クラスの関数 `stretched` に、それぞれ上下左右方向に個別の拡大縮小量を指定できるオーバーロードを追加しました。

以下のコードで動作確認済みです。
```Main.cpp
# include <Siv3D.hpp>

void Main()
{
    Rect rect{ 150, 250, 100, 100 };
    RectF rectF{ 550.0, 250.0, 100.0, 100.0 };

    auto topStretched = rect.stretched(Arg::top = 30);
    auto rightStretched = rect.stretched(Arg::right = 55.2);
    auto bottomStretched = rect.stretched(Arg::bottom = 80.8);
    auto leftStretched = rect.stretched(Arg::left = 105);

    auto topStretchedF = rectF.stretched(Arg::top = 30);
    auto rightStretchedF = rectF.stretched(Arg::right = 55.2);
    auto bottomStretchedF = rectF.stretched(Arg::bottom = 80.8);
    auto leftStretchedF = rectF.stretched(Arg::left = 105);

    while (System::Update())
    {
        rect.draw(ColorF(1.0, 1.0, 1.0));
        leftStretched.draw(ColorF(1.0, 0.0, 0.0, 0.3));
        rightStretched.draw(ColorF(0.0, 1.0, 0.0, 0.3));
        topStretched.draw(ColorF(0.0, 0.0, 1.0, 0.3));
        bottomStretched.draw(ColorF(1.0, 1.0, 0.0, 0.3));

        rectF.draw(ColorF(1.0, 1.0, 1.0));
        leftStretchedF.draw(ColorF(1.0, 0.0, 0.0, 0.3));
        rightStretchedF.draw(ColorF(0.0, 1.0, 0.0, 0.3));
        topStretchedF.draw(ColorF(0.0, 0.0, 1.0, 0.3));
        bottomStretchedF.draw(ColorF(1.0, 1.0, 0.0, 0.3));
    }
}
```

![image](https://github.com/user-attachments/assets/8093f5d2-cf1b-42ed-9521-37fd0dcb03ea)

レビューお願いします。