### PR TITLE
riderにおいてデバッグ実行時にCurrentDirectoryがAppじゃなくなる問題を解決

### DIFF
--- a/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Siv3DMain.cpp
+++ b/Siv3D/src/Siv3D-Platform/WindowsDesktop/Siv3D/Siv3DMain.cpp
@@ -268,7 +268,16 @@ namespace s3d
 			return;
 		}
 
-		if (const FilePath workingDirectory = FileSystem::ParentPath(FileSystem::ModulePath()))
+		const FilePath workingDirectory = FileSystem::ParentPath(FileSystem::ModulePath());
+		const FilePath pdbFileName = FileSystem::BaseName(FileSystem::ModulePath()) + U".pdb";
+		const FilePath pdbFilePath = FileSystem::PathAppend(workingDirectory, pdbFileName);
+
+		if(FileSystem::IsFile(pdbFilePath))
+		{
+			return;
+		}
+		
+		if (workingDirectory)
 		{
 			FileSystem::ChangeCurrentDirectory(workingDirectory);
 		}


### PR DESCRIPTION
riderでデバッグ実行を行うとCurrentDirectoryがAppフォルダではなく、Debugフォルダになってしまう問題を解決しました。

pdbファイルがexeと同じ階層に存在するかどうかで、デバッグ実行されているかを判定しています。