### PR TITLE
YesNoにoperator==を追加

### DIFF
--- a/Siv3D/include/Siv3D/YesNo.hpp
+++ b/Siv3D/include/Siv3D/YesNo.hpp
@@ -45,6 +45,18 @@ namespace s3d
 		}
 
 		[[nodiscard]]
+		constexpr bool operator ==(const YesNo<Tag>& other) const noexcept
+		{
+			return m_yesNo == other.m_yesNo;
+		}
+
+		[[nodiscard]]
+		constexpr bool operator ==(const Helper& other) const noexcept
+		{
+			return m_yesNo == other.yesNo;
+		}
+
+		[[nodiscard]]
 		constexpr bool getBool() const noexcept
 		{
 			return m_yesNo;


### PR DESCRIPTION
同一タグのYesNoの値同士が等しいかどうかの比較が可能になるよう、YesNoにoperator==を追加しました。

サンプルコード:
```cpp
# include <Siv3D.hpp>

using YN = YesNo<struct YN_tag>;
using AnotherYN = YesNo<struct AnotherYN_tag>;

void Main()
{
	YN a = YN::Yes;
	YN b = YN::No;
	AnotherYN c = AnotherYN::Yes;

	// YesNo同士の比較(従来はコンパイルエラー)
	Print << (a == b); // false
	Print << (a != b); // true

	// YesNoとHelperの比較(従来はコンパイルエラー)
	Print << (a == YN::Yes); // true
	Print << (a != YN::Yes); // false
	Print << (b == YN::No); // true
	Print << (b != YN::No); // false

	// 異なるTagのYesNoとの比較は従来通りコンパイルエラーのまま
	//Print << (a == c);
	//Print << (a == AnotherYN::Yes);

	while (System::Update())
	{
	}
}
```

実行結果:
![image](https://github.com/user-attachments/assets/c3850d5f-7749-47bb-9ca2-ddfbd24f34db)
