### PR TITLE
[macOS, Linux] 修飾キーの入力の挙動を修正

### DIFF
--- a/Siv3D/src/Siv3D-Platform/macOS_Linux/Siv3D/Keyboard/CKeyboard.cpp
+++ b/Siv3D/src/Siv3D-Platform/macOS_Linux/Siv3D/Keyboard/CKeyboard.cpp
@@ -227,8 +227,11 @@ namespace s3d
 		
 		for (auto [index, glfwKey] : detail::KeyConversionTable)
 		{
-			const bool pressed = (keys[glfwKey] == GLFW_PRESS);
-			m_states[index].update(pressed);
+			if (glfwKey != 0)
+			{
+				const bool pressed = (keys[glfwKey] == GLFW_PRESS);
+				m_states[index].update(pressed);
+			}
 		}
 		
 		{


### PR DESCRIPTION
#1299 を修正しました。

Issue に書いたとおり、 `InputState::update()` が2回呼び出されることが原因です。
for ループ内で、 `glfwKey == 0` の時に `InputState::update()` を呼び出さないようにしました。
