### PR TITLE
Array, Grid の推論補助を追加

### DIFF
--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -1248,7 +1248,7 @@ namespace s3d
 	Array(Iterator, Iterator, const Allocator& = Allocator{}) -> Array<typename std::iterator_traits<Iterator>::value_type, Allocator>;
 
 	template <class Type, class Allocator = std::allocator<Type>, std::enable_if_t<std::is_same_v<typename Allocator::value_type, Type> && (not detail::IsNamedParameter_v<Type>)>* = nullptr>
-	Array(typename Array<Type, Allocator>::size_type count, const Type& value, const Allocator& alloc = Allocator{}) -> Array<Type, Allocator>;
+	Array(typename Array<Type, Allocator>::size_type, const Type&, const Allocator& = Allocator{}) -> Array<Type, Allocator>;
 
 	template <class Fty>
 	Array(typename Array<std::decay_t<std::invoke_result_t<Fty>>>::size_type, Arg::generator_<Fty>) -> Array<std::decay_t<std::invoke_result_t<Fty>>>;

--- a/Siv3D/include/Siv3D/Array.hpp
+++ b/Siv3D/include/Siv3D/Array.hpp
@@ -1225,6 +1225,18 @@ namespace s3d
 	template <class Type, class Allocator>
 	inline void swap(Array<Type, Allocator>& a, Array<Type, Allocator>& b) noexcept;
 
+	namespace detail
+	{
+		template <class>
+		struct IsNamedParameter : std::false_type {};
+
+		template <class Tag, class Type>
+		struct IsNamedParameter<NamedParameter<Tag, Type>> : std::true_type {};
+
+		template <class Type>
+		constexpr bool IsNamedParameter_v = IsNamedParameter<Type>::value;
+	}
+
 	// deduction guide
 	template <class Type, class Allocator = std::allocator<Type>>
 	Array(std::initializer_list<Type>, const Allocator& = Allocator{}) -> Array<Type, Allocator>;
@@ -1234,6 +1246,15 @@ namespace s3d
 
 	template <class Iterator, class Allocator = std::allocator<typename std::iterator_traits<Iterator>::value_type>>
 	Array(Iterator, Iterator, const Allocator& = Allocator{}) -> Array<typename std::iterator_traits<Iterator>::value_type, Allocator>;
+
+	template <class Type, class Allocator = std::allocator<Type>, std::enable_if_t<std::is_same_v<typename Allocator::value_type, Type> && (not detail::IsNamedParameter_v<Type>)>* = nullptr>
+	Array(typename Array<Type, Allocator>::size_type count, const Type& value, const Allocator& alloc = Allocator{}) -> Array<Type, Allocator>;
+
+	template <class Fty>
+	Array(typename Array<std::decay_t<std::invoke_result_t<Fty>>>::size_type, Arg::generator_<Fty>) -> Array<std::decay_t<std::invoke_result_t<Fty>>>;
+
+	template <class Fty>
+	Array(typename Array<std::decay_t<std::invoke_result_t<Fty, size_t>>>::size_type, Arg::indexedGenerator_<Fty>) -> Array<std::decay_t<std::invoke_result_t<Fty, size_t>>>;
 
 	/// @brief 
 	/// @tparam T0 

--- a/Siv3D/include/Siv3D/Grid.hpp
+++ b/Siv3D/include/Siv3D/Grid.hpp
@@ -638,6 +638,24 @@ namespace s3d
 	template <class Type>
 	Grid(Size, Array<Type>&&) -> Grid<Type>;
 
+	template <class Type, std::enable_if_t<not detail::IsNamedParameter_v<Type>>* = nullptr>
+	Grid(typename Grid<Type>::size_type, typename Grid<Type>::size_type, const Type&) -> Grid<Type>;
+
+	template <class Type, std::enable_if_t<not detail::IsNamedParameter_v<Type>>* = nullptr>
+	Grid(Size, const Type&) -> Grid<Type>;
+
+	template <class Fty>
+	Grid(typename Grid<std::decay_t<std::invoke_result_t<Fty>>>::size_type, typename Grid<std::decay_t<std::invoke_result_t<Fty>>>::size_type, Arg::generator_<Fty>) -> Grid<std::decay_t<std::invoke_result_t<Fty>>>;
+
+	template <class Fty>
+	Grid(Size, Arg::generator_<Fty>) -> Grid<std::decay_t<std::invoke_result_t<Fty>>>;
+
+	template <class Fty>
+	Grid(typename Grid<std::decay_t<std::invoke_result_t<Fty, Point>>>::size_type, typename Grid<std::decay_t<std::invoke_result_t<Fty, Point>>>::size_type, Arg::indexedGenerator_<Fty>) -> Grid<std::decay_t<std::invoke_result_t<Fty, Point>>>;
+
+	template <class Fty>
+	Grid(Size, Arg::indexedGenerator_<Fty>) -> Grid<std::decay_t<std::invoke_result_t<Fty, Point>>>;
+
 	template <class Type, class Allocator>
 	inline void swap(Grid<Type, Allocator>& a, Grid<Type, Allocator>& b) noexcept;
 }


### PR DESCRIPTION
#1307 の修正と、機能追加です。

## 追加される機能

- 新たに以下のコンストラクタで CTAD が効くようになります
  - `Array(size_type count, const value_type& value, const Allocator& alloc = Allocator{})`
  - `Array(size_type size, Arg::generator_<Fty> generator)`
  - `Array(size_type size, Arg::indexedGenerator_<Fty> indexedGenerator)`
  - `Grid(size_type w, size_type h, const value_type& value)`
  - `Grid(Size size, const value_type& value)`
  - `Grid(size_type w, size_type h, Arg::generator_<Fty> generator)`
  - `Grid(Size size, Arg::generator_<Fty> generator)`
  - `Grid(size_type w, size_type h, Arg::indexedGenerator_<Fty> indexedGenerator)`
  - `Grid(Size size, Arg::indexedGenerator_<Fty> indexedGenerator)`
- Issue では `const value_type&` を引数に取るコンストラクタについて問題提起しましたが、この問題を解決するにあたって `Arg::generator` や `Arg::indexedGenerator` を考慮する必要があったので、一緒に `Arg::generator` や `Arg::indexedGenerator` を取るコンストラクタでも CTAD が効くようにしました
- この PR で `Grid g(2, 2, Array<int, Allocator<int>>{})` のようなコードが有効に**なってしまいます**
  - コンストラクタ `Grid(size_type w, size_type h, const Array<value_type>& data)` の引数 `data` は `Grid::allocator_type` にかかわらずデフォルトのアロケータを使用する `Array` であり、 `Array<int, Allocator<int>>` などの値は渡せません
  - 変更前はエラーでしたが、変更後は以下のように CTAD が非直感的に働く可能性があります
  - ```cpp
    Array<int> a1{ 3, 1, 4, 1 };
    Array<int, Allocator<int>> a2{ 3, 1, 4, 1 };
    Grid g1(2, 2, a1);  // Grid<int> に推論される
    Grid g2(2, 2, a2);  // Grid<Array<int, Allocator<int>>> に推論される（！）
    ```

## 実装

- `Array.hpp`, `Grid.hpp` に推論補助を追加しました
- 追加した推論補助 `Array(typename Array<Type, Allocator>::size_type, const Type&, const Allocator& = Allocator{}) -> Array<Type, Allocator>` には以下のような問題があったため、 `std::is_same_v<typename Allocator::value_type, Type>` でこの推論補助を制約しています
  - ```cpp
    std::list<int> list{ 3, 1, 4, 1 };
    Allocator<int> alloc;
    Array a(list.begin(), list.end(), alloc);  // Array<std::list<int>::iterator, Allocator<int>> に推論され、コンパイルエラー
    ```
- 追加した推論補助 `Array(typename Array<Type, Allocator>::size_type, const Type&, const Allocator& = Allocator{}) -> Array<Type, Allocator>` および対応する `Grid` の推論補助には以下のような問題があったため、 `not detail::IsNamedParameter_v<Type>` でこれらの推論補助を制約しています
  - ```cpp
    Array a(3, Arg::generator = [] { return 42; });  // Array<Arg::generator_<...>> に推論される
    Grid g1(2, 2, Arg::generator = [] { return 42; });  // Grid<Arg::generator_<...>> に推論される
    Grid g2(Size{ 2, 2 }, Arg::generator = [] { return 42; });  // Grid<Arg::generator_<...>> に推論される
    ```
  - `detail::IsNamedParameter_v` を定義し、~~面倒だったので~~ `Arg::generator`, `Arg::indexedGenerator` だけでなくすべての `NamedParameter` を弾いています
  - `detail::IsNamedParameter_v` の定義は少し変なところに置いており、適切ではないかもしれません

## テストコード

```cpp
# include <Siv3D.hpp> // Siv3D v0.6.16

struct ArrayIsh
{
	const Array<int, Allocator<int>>& asArray() const;
};

static_assert(requires (
	Array<int, Allocator<int>> a,
	std::vector<int, Allocator<int>> v,
	Allocator<int> alloc)
{
	{ Array(a)            } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(a)) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(v)            } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(v)) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(3, 42)        } -> std::same_as<Array<int>>;
	{ Array(3, 42, alloc) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(a.begin(), a.end())        } -> std::same_as<Array<int>>;
	{ Array(a.begin(), a.end(), alloc) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(a)                   } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(a, alloc)            } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(a))        } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(a), alloc) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(v)                   } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(v, alloc)            } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(v))        } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(std::move(v), alloc) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array({ 42, 42, 42 })        } -> std::same_as<Array<int>>;
	{ Array({ 42, 42, 42 }, alloc) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(ArrayIsh{}) } -> std::same_as<Array<int, Allocator<int>>>;
	{ Array(3, Arg::generator = [] { return 42; }) } -> std::same_as<Array<int>>;
	{ Array(3, Arg::indexedGenerator = [](size_t) { return 42; }) } -> std::same_as<Array<int>>;
});

static_assert(requires (
	Grid<int, Allocator<int>> g,
	Array<int> a,
	Allocator<int> alloc)
{
	{ Grid(g)            } -> std::same_as<Grid<int, Allocator<int>>>;
	{ Grid(std::move(g)) } -> std::same_as<Grid<int, Allocator<int>>>;
	{ Grid(2, 2, 42) } -> std::same_as<Grid<int>>;
	{ Grid(Size{ 2, 2 }, 42) } -> std::same_as<Grid<int>>;
	{ Grid(2, 2, a)            } -> std::same_as<Grid<int>>;
	{ Grid(2, 2, std::move(a)) } -> std::same_as<Grid<int>>;
	{ Grid(Size{ 2, 2 }, a)            } -> std::same_as<Grid<int>>;
	{ Grid(Size{ 2, 2 }, std::move(a)) } -> std::same_as<Grid<int>>;
	{ Grid({ { 42, 42 }, { 42, 42 } }) } -> std::same_as<Grid<int>>;
	{ Grid(2, 2, Arg::generator = [] { return 42; })         } -> std::same_as<Grid<int>>;
	{ Grid(Size{ 2, 2 }, Arg::generator = [] { return 42; }) } -> std::same_as<Grid<int>>;
	{ Grid(2, 2, Arg::indexedGenerator = [](Point) { return 42; })         } -> std::same_as<Grid<int>>;
	{ Grid(Size{ 2, 2 }, Arg::indexedGenerator = [](Point) { return 42; }) } -> std::same_as<Grid<int>>;
});

void Main()
{
	while (System::Update())
	{

	}
}
```
