### PR TITLE
macOS・Linuxにてマウスボタン押下時に`System::GetUserActions()`の戻り値に`UserAction::MouseButtonDown`が立たないのを修正

### DIFF
--- a/Siv3D/src/Siv3D-Platform/macOS_Linux/Siv3D/Mouse/CMouse.cpp
+++ b/Siv3D/src/Siv3D-Platform/macOS_Linux/Siv3D/Mouse/CMouse.cpp
@@ -11,7 +11,9 @@
 
 # include <Siv3D/Common.hpp>
 # include <Siv3D/EngineLog.hpp>
+# include <Siv3D/UserAction.hpp>
 # include <Siv3D/Window/IWindow.hpp>
+# include <Siv3D/UserAction/IUserAction.hpp>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 # include "CMouse.hpp"
 
@@ -80,6 +82,11 @@ namespace s3d
 				{
 					m_allInputs.emplace_back(InputDeviceType::Mouse, static_cast<uint8>(i));
 				}
+			}
+
+			if (m_allInputs.any([](const Input& input) { return input.down(); }))
+			{
+				SIV3D_ENGINE(UserAction)->reportUserActions(UserAction::MouseButtonDown);
 			}
 		}
 	}


### PR DESCRIPTION
下記Issueの修正です。

https://github.com/Siv3D/OpenSiv3D/issues/1324

siv8にある下記の内容と同じ処理を追加しました。

https://github.com/Siv3D/siv8/blob/a80d41f6604a9b0c97068aaab5bc2de22d163d71/Siv3D/src/Siv3D-Platform/macOS_Linux/Siv3D/Mouse/CMouse.cpp#L80-L83