### PR TITLE
fix: Add NULL check to GLFWwindow*

### DIFF
--- a/Siv3D/src/Siv3D-Platform/macOS/Siv3D/TextInput/CTextInput.cpp
+++ b/Siv3D/src/Siv3D-Platform/macOS/Siv3D/TextInput/CTextInput.cpp
@@ -46,9 +46,10 @@ namespace s3d
 	{
 		LOG_SCOPED_TRACE(U"CTextInput::init()");
 
-		GLFWwindow* glfwWindow = static_cast<GLFWwindow*>(SIV3D_ENGINE(Window)->getHandle());
-		
-		::glfwSetCharCallback(glfwWindow, OnCharacterInput);
+        if (GLFWwindow* glfwWindow = static_cast<GLFWwindow*>(SIV3D_ENGINE(Window)->getHandle()))
+        {
+            ::glfwSetCharCallback(glfwWindow, OnCharacterInput);
+        }
 	}
 	
 	void CTextInput::update()


### PR DESCRIPTION
## What

Mac版のCTextInput::init()にGLFWwindow*のNULLチェックを追加

## Why

Headlessモードでは`SIV3D_ENGINE(Window)->getHandle()`がNULLを返してしまい、後続の`glfwSetCharCallback`の内部でassertionエラーが発生していました。Linux版のコードではNULLだった場合呼び出しをしていなかったため同様の対応をしました。
https://github.com/Siv3D/OpenSiv3D/blob/8458f3d8d5b974eeabbc6c3824d4648b48bf0cfa/Siv3D/src/Siv3D-Platform/Linux/Siv3D/TextInput/CTextInput.cpp#L101-L109

## How to test

Headlessモードを有効にしたMain.cppでクラッシュしないこと

```cpp
# include <Siv3D.hpp> // Siv3D v0.6.16

SIV3D_SET(EngineOption::Renderer::Headless)

void Main()
{
	
}
```