### PR TITLE
[Fix issue1323] FileSystem::ModulePath()の結果絶対パスになるように修正する

### DIFF
--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Siv3DMain.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Siv3DMain.cpp
@@ -10,6 +10,8 @@
 //-----------------------------------------------
 
 # include <iostream>
+#include <unistd.h>
+#include <limits.h>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 # include <Siv3D/System/ISystem.hpp>
 # include <Siv3D/Error.hpp>
@@ -28,8 +30,16 @@ int main(int argc, char* argv[])
 	using namespace s3d;
 	std::clog << "OpenSiv3D for Linux\n";
 
+	char absolutePath[PATH_MAX] = {};
+    ssize_t absolutePathLen = readlink("/proc/self/exe", absolutePath, sizeof(absolutePath)-1);
+    if (absolutePathLen == -1)
+	{
+		std::cerr << "Failed to get module path\n";
+		return -1;
+	}
+    absolutePath[absolutePathLen] = '\0';
 	detail::init::InitCommandLines(argc, argv);
-	detail::init::InitModulePath(argv[0]);
+	detail::init::InitModulePath(absolutePath);
 
 	Siv3DEngine engine;
 	

--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Siv3DMain.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Siv3DMain.cpp
@@ -10,8 +10,8 @@
 //-----------------------------------------------
 
 # include <iostream>
-#include <unistd.h>
-#include <limits.h>
+# include <unistd.h>
+# include <limits.h>
 # include <Siv3D/Common/Siv3DEngine.hpp>
 # include <Siv3D/System/ISystem.hpp>
 # include <Siv3D/Error.hpp>


### PR DESCRIPTION
# 概要

[issue1323](https://github.com/Siv3D/OpenSiv3D/issues/1323)に対する修正

レビューをお願いします

# 検証

以下のようなMain.cppを用意する

```diff
# include <Siv3D.hpp> // Siv3D v0.6.16
SIV3D_SET(EngineOption::Renderer::Headless) // Force non-graphical mode
void Main()
{
	Console << U"\n----------------";
	Console << U"Hello, Siv3D!";
	Console << U"You are running a non-graphical program.";
	Console << U"You can code a graphical program in Linux/App/Main.cpp";
	Console << U"----------------\n";
+	Console << FileSystem::ModulePath();
}
```

本PRの変更をビルドし，Main.cppをビルド

実行結果

<details>

<summary> /Linux配下 </summary>


```sh
aoto@naoto-MB-K700:~/OSS/Siv3D/fork/OpenSiv3D/Linux$ pwd
/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux
naoto@naoto-MB-K700:~/OSS/Siv3D/fork/OpenSiv3D/Linux$ ./App/Siv3DTest 
OpenSiv3D for Linux
0: [info]    ℹ️ 2026-02-21 19:37:45
0: [info]    ℹ️ Siv3D Engine (0.6.16) Linux [Release build]
0: [info]    ℹ️ OS: Ubuntu 22.04.5 LTS (22.4.0.0)
0: [info]    ℹ️ CPU: GenuineIntel Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz 6.158.13 (CPU packages: 1, Physical CPUs: 12, Logical CPUs: 12)
0: [info]    ℹ️ Memory: [Physical Available: 27.6GiB Total: 31.2GiB] [Virtual: Available: 32TiB Total: 32TiB]
0: [info]    ℹ️ Connected displays: 0
0: [info]    ⌛ Preparing for setup...
0: [info]    soundfontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/soundfont/
0: [info]    ℹ️ Engine font `GMGSx.sf2` found in the user cache directory
1: [info]    libmpg123 is available
4: [info]    🎧 Audio backend: MiniAudio (channel count: 2, sample rate: 44100, buffer size: 441)
6: [info]    ℹ️ SoundTouch is available
6: [info]    Default Screenshot directory: "/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/Screenshot/"
6: [info]    fontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/font/
6: [info]    ℹ️ Engine font `noto-cjk/NotoSansCJK-Regular.ttc` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoEmoji-Regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoColorEmoji.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-thin.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-light.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-medium.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-bold.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-heavy.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-black.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-solid.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-brands.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `materialdesignicons/materialdesignicons-webfont.ttf` found in the user cache directory

----------------
Hello, Siv3D!
You are running a non-graphical program.
You can code a graphical program in Linux/App/Main.cpp
----------------

/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/App/Siv3DTest
2009: [info]    ✅ Siv3D engine has terminated
2009: [info]    ℹ️ 2026-02-21 19:37:47
```

</details>

<details>
<summary> /Linux/App配下 </summary>

```sh
naoto@naoto-MB-K700:~/OSS/Siv3D/fork/OpenSiv3D/Linux/App$ ./Siv3DTest 
OpenSiv3D for Linux
0: [info]    ℹ️ 2026-02-21 19:39:03
0: [info]    ℹ️ Siv3D Engine (0.6.16) Linux [Release build]
0: [info]    ℹ️ OS: Ubuntu 22.04.5 LTS (22.4.0.0)
0: [info]    ℹ️ CPU: GenuineIntel Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz 6.158.13 (CPU packages: 1, Physical CPUs: 12, Logical CPUs: 12)
0: [info]    ℹ️ Memory: [Physical Available: 27.6GiB Total: 31.2GiB] [Virtual: Available: 32TiB Total: 32TiB]
0: [info]    ℹ️ Connected displays: 0
0: [info]    ⌛ Preparing for setup...
0: [info]    soundfontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/soundfont/
0: [info]    ℹ️ Engine font `GMGSx.sf2` found in the user cache directory
0: [info]    libmpg123 is available
4: [info]    🎧 Audio backend: MiniAudio (channel count: 2, sample rate: 44100, buffer size: 441)
6: [info]    ℹ️ SoundTouch is available
6: [info]    Default Screenshot directory: "/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/App/Screenshot/"
6: [info]    fontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/font/
6: [info]    ℹ️ Engine font `noto-cjk/NotoSansCJK-Regular.ttc` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoEmoji-Regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoColorEmoji.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-thin.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-light.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-medium.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-bold.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-heavy.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-black.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-solid.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-brands.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `materialdesignicons/materialdesignicons-webfont.ttf` found in the user cache directory

----------------
Hello, Siv3D!
You are running a non-graphical program.
You can code a graphical program in Linux/App/Main.cpp
----------------

/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/App/Siv3DTest
2010: [info]    ✅ Siv3D engine has terminated
2010: [info]    ℹ️ 2026-02-21 19:39:05
```

</details>


</details>

<details>
<summary> 絶対パスで実行 </summary>

```sh
naoto@naoto-MB-K700:~/OSS/Siv3D/fork/OpenSiv3D/Linux/App$ ls
CMakeCache.txt  CMakeLists.txt     CPackSourceConfig.cmake  Siv3DTest  build.ninja          example
CMakeFiles      CPackConfig.cmake  Main.cpp                 build      cmake_install.cmake  resources
naoto@naoto-MB-K700:~$ /home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/App/Siv3DTest
OpenSiv3D for Linux
0: [info]    ℹ️ 2026-02-21 19:44:09
0: [info]    ℹ️ Siv3D Engine (0.6.16) Linux [Release build]
0: [info]    ℹ️ OS: Ubuntu 22.04.5 LTS (22.4.0.0)
0: [info]    ℹ️ CPU: GenuineIntel Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz 6.158.13 (CPU packages: 1, Physical CPUs: 12, Logical CPUs: 12)
0: [info]    ℹ️ Memory: [Physical Available: 27.6GiB Total: 31.2GiB] [Virtual: Available: 32TiB Total: 32TiB]
0: [info]    ℹ️ Connected displays: 0
0: [info]    ⌛ Preparing for setup...
0: [info]    soundfontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/soundfont/
0: [info]    ℹ️ Engine font `GMGSx.sf2` found in the user cache directory
1: [info]    libmpg123 is available
4: [info]    🎧 Audio backend: MiniAudio (channel count: 2, sample rate: 44100, buffer size: 441)
6: [info]    ℹ️ SoundTouch is available
6: [info]    Default Screenshot directory: "/home/naoto/Screenshot/"
6: [info]    fontCacheDirectory: /home/naoto/.cache/Siv3D/0.6.16/font/
6: [info]    ℹ️ Engine font `noto-cjk/NotoSansCJK-Regular.ttc` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoEmoji-Regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `noto-emoji/NotoColorEmoji.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-thin.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-light.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-regular.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-medium.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-bold.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-heavy.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `mplus/mplus-1p-black.ttf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-solid.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `fontawesome/fontawesome-brands.otf` found in the user cache directory
6: [info]    ℹ️ Engine font `materialdesignicons/materialdesignicons-webfont.ttf` found in the user cache directory

----------------
Hello, Siv3D!
You are running a non-graphical program.
You can code a graphical program in Linux/App/Main.cpp
----------------

/home/naoto/OSS/Siv3D/fork/OpenSiv3D/Linux/App/Siv3DTest
2010: [info]    ✅ Siv3D engine has terminated
2010: [info]    ℹ️ 2026-02-21 19:44:11
```

</details>