### PR TITLE
fix: Endian.ipp error on Windows for C++20 build

### DIFF
--- a/Siv3D/include/Siv3D/detail/Endian.ipp
+++ b/Siv3D/include/Siv3D/detail/Endian.ipp
@@ -11,7 +11,7 @@
 
 # pragma once
 # if SIV3D_PLATFORM(WINDOWS)
-#	include <bit>
+#	include <cstdlib>
 # elif SIV3D_PLATFORM(MACOS)
 #	include <libkern/OSByteOrder.h>
 # endif
@@ -22,17 +22,17 @@ namespace s3d
 
 	inline uint16 SwapEndian(const uint16 value) noexcept
 	{
-		return std::byteswap(value);
+		return _byteswap_ushort(value);
 	}
 
 	inline uint32 SwapEndian(const uint32 value) noexcept
 	{
-		return std::byteswap(value);
+		return _byteswap_ulong(value);
 	}
 
 	inline uint64 SwapEndian(const uint64 value) noexcept
 	{
-		return std::byteswap(value);
+		return _byteswap_uint64(value);
 	}
 
 # elif SIV3D_PLATFORM(MACOS)


### PR DESCRIPTION
## Problem

  I ran into a build error using Siv3D headers under `/std:c++20` on MSVC. `Endian.ipp` (Windows branch) uses `std::byteswap`, which is a C++23 library feature rather than C++20, so compilation fails with:

  `error C2039: 'byteswap': is not a member of 'std'`

  It builds fine under `/std:c++latest` (which is what `Siv3D.vcxproj` uses), so this only shows up when consuming the headers from a C++20 project.

  ## Fix

  Swap the three Windows-branch calls for the MSVC intrinsics `_byteswap_ushort` / `_byteswap_ulong` / `_byteswap_uint64` from `<cstdlib>`. These are available regardless of `/std:` mode, so the Windows branch compiles cleanly under both `/std:c++20` and `/std:c++latest`.

  The macOS branch, the generic fallback, and the public `Endian.hpp` API are untouched.