### PR TITLE
[macOS, Linux, Web] WindowState の更新処理を修正

### DIFF
--- a/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Window/CWindow.cpp
+++ b/Siv3D/src/Siv3D-Platform/Linux/Siv3D/Window/CWindow.cpp
@@ -333,7 +333,7 @@ namespace s3d
 		m_state.bounds.size = Size(windowSizeX, (windowSizeY + m_state.titleBarHeight));
 				
 		// minimized
-		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
+		m_state.minimized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
 		
 		// maximized
 		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) == GLFW_TRUE)

--- a/Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/CWindow.cpp
+++ b/Siv3D/src/Siv3D-Platform/Web/Siv3D/Window/CWindow.cpp
@@ -321,7 +321,7 @@ namespace s3d
 		m_state.bounds.size = Size(windowSizeX, (windowSizeY + m_state.titleBarHeight));
 				
 		// minimized
-		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
+		m_state.minimized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
 		
 		// maximized
 		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) == GLFW_TRUE)

--- a/Siv3D/src/Siv3D-Platform/macOS/Siv3D/Window/CWindow.cpp
+++ b/Siv3D/src/Siv3D-Platform/macOS/Siv3D/Window/CWindow.cpp
@@ -323,7 +323,7 @@ namespace s3d
 		m_state.bounds.size = Size(windowSizeX, (windowSizeY + m_state.titleBarHeight));
 				
 		// minimized
-		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
+		m_state.minimized = (::glfwGetWindowAttrib(m_window, GLFW_ICONIFIED) == GLFW_TRUE);
 		
 		// maximized
 		m_state.maximized = (::glfwGetWindowAttrib(m_window, GLFW_MAXIMIZED) == GLFW_TRUE)


### PR DESCRIPTION
`m_state.minimized` を更新すべきところで `m_state.maximized` に書き込んでいたのを修正しました。

`updateState()` で `m_state.minimized` が更新されていませんでしたが、　`OnIconify()`, `OnMaximize()` で正しく更新されていたので、現状でもちゃんと動いていたようです。
