### PR TITLE
[OpenGL, OpenGLES] スクリーンショットの処理を修正

### DIFF
--- a/Siv3D/src/Siv3D-Platform/OpenGL4/Siv3D/Renderer/GL4/BackBuffer/GL4BackBuffer.cpp
+++ b/Siv3D/src/Siv3D-Platform/OpenGL4/Siv3D/Renderer/GL4/BackBuffer/GL4BackBuffer.cpp
@@ -106,7 +106,7 @@ namespace s3d
 
 		if (m_sampleCount == 1)
 		{
-			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.scene->getTexture());
+			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.scene->getFrameBuffer());
 			{
 				::glReadPixels(0, 0, m_sceneSize.x, m_sceneSize.y, GL_RGBA, GL_UNSIGNED_BYTE, m_screenCaptureImage.data());
 			}
@@ -114,7 +114,7 @@ namespace s3d
 		}
 		else
 		{
-			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.resolved->getTexture());
+			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.resolved->getFrameBuffer());
 			{
 				::glReadPixels(0, 0, m_sceneSize.x, m_sceneSize.y, GL_RGBA, GL_UNSIGNED_BYTE, m_screenCaptureImage.data());
 			}

--- a/Siv3D/src/Siv3D-Platform/OpenGLES3/Siv3D/Renderer/GLES3/BackBuffer/GLES3BackBuffer.cpp
+++ b/Siv3D/src/Siv3D-Platform/OpenGLES3/Siv3D/Renderer/GLES3/BackBuffer/GLES3BackBuffer.cpp
@@ -106,7 +106,7 @@ namespace s3d
 
 		if (m_sampleCount == 1)
 		{
-			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.scene->getTexture());
+			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.scene->getFrameBuffer());
 			{
 				::glReadPixels(0, 0, m_sceneSize.x, m_sceneSize.y, GL_RGBA, GL_UNSIGNED_BYTE, m_screenCaptureImage.data());
 			}
@@ -114,7 +114,7 @@ namespace s3d
 		}
 		else
 		{
-			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.resolved->getTexture());
+			::glBindFramebuffer(GL_FRAMEBUFFER, m_sceneBuffers.resolved->getFrameBuffer());
 			{
 				::glReadPixels(0, 0, m_sceneSize.x, m_sceneSize.y, GL_RGBA, GL_UNSIGNED_BYTE, m_screenCaptureImage.data());
 			}


### PR DESCRIPTION
OpenGL 4.1, OpenGL ES 3.0 のスクリーンショットの処理の中で、 framebuffer object を渡すべきところに texture object を渡しているコードがあったので、 framebuffer object を渡すように修正しました。

Web 版で OpenGL ES 3.0 を使うとスクリーンショットがおかしくなることを確認しました (https://github.com/Raclamusi/OpenSiv3D/issues/32) 。

Windows 版や macOS 版で OpenGL 4.1 を使った場合は、なぜか正しくスクリーンショットを取得できるようでした。
